### PR TITLE
Create dependabot.yml to keep bpod-core updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "bpod-core"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "bpod-core"
+    target-branch: "dev"


### PR DESCRIPTION
> As a developer, I want a new `bpod-core` release to trigger a Pull Request in `bpod-rig/dev`.

Since new features are regularly added to `bpod-core`, we should keep it up to date as much as possible. This GitHub workflow should make Dependabot open a new PR at the end of the day if it finds that `bpod-core` has been updated.

We should intend for this workflow to be in place until at `bpod-core` is at least out of alpha.

#42 targeted `dev` but I think this needs to be in main.