### PR TITLE
Fix ruff formatting and pyright type checking

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,10 +30,12 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Run tests with coverage
+      - name: Run checks and tests with coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+            uv run ruff check .
+            uv run pyright .
             uv sync --locked --all-extras
             uv run python -m pytest --cov --cov-report=xml
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -34,9 +34,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+            uv sync --locked --all-extras
             uv run ruff check .
             uv run pyright .
-            uv sync --locked --all-extras
             uv run python -m pytest --cov --cov-report=xml
 
       # - name: Upload coverage to Coveralls

--- a/bpod_rig/IO/reset.py
+++ b/bpod_rig/IO/reset.py
@@ -38,10 +38,12 @@ def reset_all(directories: Iterable[Path | str], force=False) -> bool:
             "related directories on this machine?"
         )
         if confirmation:
-            confirmation &= cli_io.yes_no_prompt(
+            final_confirmation = cli_io.yes_no_prompt(
                 "Final warning: Are you SURE you want to delete all "
                 "Bpod-related directories?"
             )
+            if not final_confirmation and not confirmation:
+                return False
 
         if not confirmation:
             return False

--- a/bpod_rig/IO/startup.py
+++ b/bpod_rig/IO/startup.py
@@ -3,13 +3,13 @@
 import logging
 from pathlib import Path
 
-from bpod_rig.examples.copy import copy_examples
 from bpod_rig.config import system_settings
 from bpod_rig.defaults import (
     DEFAULT_SUBDIRS,
     SYSTEM_CONFIG_DIR,
     SYSTEM_CONFIG_FILE,
 )
+from bpod_rig.examples.copy import copy_examples
 
 logger = logging.getLogger(__name__)
 

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -1,11 +1,13 @@
 """main entry point for bpod-rig."""
 
 import logging
+
+from pydantic import ValidationError
+
 from bpod_rig.config import utils
 from bpod_rig.config.system_settings import BpodDir
 from bpod_rig.defaults import DEFAULT_BPOD_PATH, SYSTEM_CONFIG_DIR, SYSTEM_CONFIG_FILE
-from bpod_rig.IO import startup, cli_io
-from pydantic import ValidationError
+from bpod_rig.IO import cli_io, startup
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -84,7 +84,7 @@ def main():
     ## Verify Bpod Folder Structure ##
 
     # Instantiate BpodDir object to generate subdirectories
-    system_paths = BpodDir(base_dir=bpod_path)
+    system_paths = BpodDir.create(base_dir=bpod_path)
     if system_initialized:
         # Let's only verify the directory if Bpod has already been
         # initialized on this system

--- a/bpod_rig/calibration/liquid/models.py
+++ b/bpod_rig/calibration/liquid/models.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 
 import numpy as np
-from pydantic import BaseModel, Field, ConfigDict, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 logger = logging.getLogger(__name__)
 

--- a/bpod_rig/calibration/liquid/pending_calibration.py
+++ b/bpod_rig/calibration/liquid/pending_calibration.py
@@ -1,11 +1,11 @@
 import logging
 from typing import Any
 
-from bpod_rig.calibration.liquid.models import ValveDataManager, ValveData
 import bpod_core.bpod
 from bpod_core.fsm import StateMachine
 from pydantic import Field
 
+from bpod_rig.calibration.liquid.models import ValveData, ValveDataManager
 
 logger = logging.getLogger(__name__)
 

--- a/bpod_rig/calibration/liquid/pending_calibration.py
+++ b/bpod_rig/calibration/liquid/pending_calibration.py
@@ -328,12 +328,10 @@ def run_calibration(
         logger.info("\t%s between each pulse set.", pending_manager.pulse_set_pause)
         for valvename in test_set:
             logger.info("- %s: duration %s ms", valvename, test_set[valvename])
-
-    bpodsystem.send_state_machine(fsm)
     logger.debug("Running calibration state machine.")
     # Run the state machine
     for _ in range(pending_manager.n_pulses):
-        bpodsystem.run_state_machine()
+        bpodsystem.run(fsm)
     if verbose:
         logger.info("Calibration state machine completed.")
 

--- a/bpod_rig/calibration/liquid/populate_examples.py
+++ b/bpod_rig/calibration/liquid/populate_examples.py
@@ -3,9 +3,9 @@
 import datetime
 from pathlib import Path
 
-from bpod_rig.examples import calibration as example_folder
 from bpod_rig.calibration.liquid.models import ValveDataManager
 from bpod_rig.calibration.liquid.utils import create_empty_valve_data_manager
+from bpod_rig.examples import calibration as example_folder
 
 
 def add_dummy_measurements(valvemanager: ValveDataManager) -> None:

--- a/bpod_rig/calibration/liquid/utils.py
+++ b/bpod_rig/calibration/liquid/utils.py
@@ -109,8 +109,8 @@ def calculate_largest_gap_midpoint(sorted_values: list[float]) -> float:
 
 
 def linearly_suggest_duration(
-    amount: float | np.typing.ArrayLike,
-    duration: float | np.typing.ArrayLike,
+    amount: float,
+    duration: float,
     range_low: float,
     range_high: float,
 ) -> float:
@@ -129,7 +129,7 @@ def linearly_suggest_duration(
 
 
 def calculate_ranged_amounts(
-    amounts: np.array, range_low: float, range_high: float
+    amounts: np.ndarray, range_low: float, range_high: float
 ) -> list[float]:
     """Calculate a sorted list of amounts within a range, including the range bounds."""
     amounts_vector = amounts.tolist()

--- a/bpod_rig/calibration/liquid/utils.py
+++ b/bpod_rig/calibration/liquid/utils.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+
 import numpy as np
 
 from bpod_rig.calibration.liquid.models import ValveData, ValveDataManager

--- a/bpod_rig/config/base.py
+++ b/bpod_rig/config/base.py
@@ -40,7 +40,7 @@ class SettingsMetadata(BaseModel):
     ] = None
 
     username: Annotated[
-        str,
+        Optional[str],
         Field(
             min_length=1,
             max_length=128,
@@ -73,8 +73,8 @@ class ModelWithMetadata(BaseModel):
 
     metadata: Annotated[
         SettingsMetadata,
-        Field(title="Model metadata", default_factory=lambda: SettingsMetadata()),
-    ] = None
+        Field(title="Model metadata", default_factory=SettingsMetadata),
+    ]
 
     # noinspection PyNestedDecorators
     @model_validator(mode="before")

--- a/bpod_rig/config/bpod_settings.py
+++ b/bpod_rig/config/bpod_settings.py
@@ -168,9 +168,13 @@ class BpodPaths(ModelWithMetadata):
         PosixPath('/home/user/Bpods/Machine-1234')
         """
         parent_dir = Path(parent_dir)
-        unique_bpod_dir = Path(unique_bpod_dir or parent_dir / f"Machine-{bpod_id}")
-        settings_dir = Path(settings_dir or unique_bpod_dir / "Settings")
-        calibration_dir = Path(calibration_dir or unique_bpod_dir / "Calibration")
+        unique_bpod_dir = Path(
+            unique_bpod_dir or parent_dir.joinpath(f"Machine-{bpod_id}")
+        )
+        settings_dir = Path(settings_dir or unique_bpod_dir.joinpath("Settings"))
+        calibration_dir = Path(
+            calibration_dir or unique_bpod_dir.joinpath("Calibration")
+        )
 
         return cls(
             bpod_id=bpod_id,

--- a/bpod_rig/config/bpod_settings.py
+++ b/bpod_rig/config/bpod_settings.py
@@ -1,11 +1,11 @@
 """Module implementing the Pydantic models for any Bpod-specific settings."""
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 from pydantic import Field
 
-from bpod_rig.config.base import ModelWithMetadata
+from bpod_rig.config.base import ModelWithMetadata, SettingsMetadata
 
 
 def subdir_path_factory(data: dict, addition: str):
@@ -57,6 +57,12 @@ def unique_dir_path_factory(data: dict):
 
 
 class BpodPaths(ModelWithMetadata):
+    """Path configuration for a unique Bpod instance.
+
+    Use the `create()` class method to construct instances with automatic
+    subdirectory path generation from the parent directory and bpod_id.
+    """
+
     bpod_id: Annotated[
         str,
         Field(
@@ -82,35 +88,96 @@ class BpodPaths(ModelWithMetadata):
         Field(
             title="Directory for this unique Bpod",
             description="Absolute path to the directory for this unique Bpod",
-            default_factory=lambda data: unique_dir_path_factory(data),
         ),
-    ] = None
+    ]
 
     settings_dir: Annotated[
-        Optional[Path],
+        Path,
         Field(
             title="Bpod Settings Subdirectory",
             description="Sub directory where Bpod settings files are "
             "stored for this unique Bpod",
-            default_factory=lambda data: subdir_path_factory(data, "Settings"),
         ),
-    ] = None
+    ]
 
     calibration_dir: Annotated[
-        Optional[Path],
+        Path,
         Field(
-            default_factory=lambda data: subdir_path_factory(data, "Calibration"),
             title="Bpod Calibration Directory",
             description="Local directory where Bpod calibration files are stored.",
         ),
-    ] = None
+    ]
 
     calibration_files: Annotated[
-        Optional[dict[str, Path]],
+        dict[str, Path],
         Field(
-            {},
+            default_factory=dict,
             title="Bpod calibration files",
             description="Dictionary of calibration files found in the calibration "
             "directory for this Bpod.",
         ),
-    ] = None
+    ]
+
+    @classmethod
+    def create(
+        cls,
+        bpod_id: str,
+        parent_dir: Path | str,
+        *,
+        unique_bpod_dir: Path | str | None = None,
+        settings_dir: Path | str | None = None,
+        calibration_dir: Path | str | None = None,
+        calibration_files: dict[str, Path] | None = None,
+        username: str | None = None,
+        metadata: "SettingsMetadata | None" = None,
+    ) -> "BpodPaths":
+        """Factory method to create BpodPaths with automatic subdirectory paths.
+
+        This is the recommended way to create BpodPaths instances. It automatically
+        generates subdirectory paths based on the parent_dir and bpod_id if not
+        explicitly provided.
+
+        Parameters
+        ----------
+        bpod_id : str
+            Unique identifier for this Bpod
+        parent_dir : Path | str
+            Parent directory for Bpod-specific folders
+        unique_bpod_dir : Path | str | None, optional
+            Override for unique Bpod directory (default: parent_dir/Machine-{bpod_id})
+        settings_dir : Path | str | None, optional
+            Override for settings directory (default: unique_bpod_dir/Settings)
+        calibration_dir : Path | str | None, optional
+            Override for calibration directory (default: unique_bpod_dir/Calibration)
+        calibration_files : dict[str, Path] | None, optional
+            Calibration files dictionary
+        username : str | None, optional
+            Username for metadata
+        metadata : SettingsMetadata | None, optional
+            Pre-constructed metadata object
+
+        Returns
+        -------
+        BpodPaths
+            Fully initialized BpodPaths instance with all subdirectory paths populated
+
+        Examples
+        --------
+        >>> paths = BpodPaths.create(bpod_id="1234", parent_dir="/home/user/Bpods")
+        >>> paths.unique_bpod_dir
+        PosixPath('/home/user/Bpods/Machine-1234')
+        """
+        parent_dir = Path(parent_dir)
+        unique_bpod_dir = Path(unique_bpod_dir or parent_dir / f"Machine-{bpod_id}")
+        settings_dir = Path(settings_dir or unique_bpod_dir / "Settings")
+        calibration_dir = Path(calibration_dir or unique_bpod_dir / "Calibration")
+
+        return cls(
+            bpod_id=bpod_id,
+            parent_dir=parent_dir,
+            unique_bpod_dir=unique_bpod_dir,
+            settings_dir=settings_dir,
+            calibration_dir=calibration_dir,
+            calibration_files=calibration_files or {},
+            metadata=metadata or SettingsMetadata(username=username or None),
+        )

--- a/bpod_rig/config/bpod_settings.py
+++ b/bpod_rig/config/bpod_settings.py
@@ -1,9 +1,11 @@
 """Module implementing the Pydantic models for any Bpod-specific settings."""
 
-from bpod_rig.config.base import ModelWithMetadata
 from pathlib import Path
-from pydantic import Field
 from typing import Annotated, Optional
+
+from pydantic import Field
+
+from bpod_rig.config.base import ModelWithMetadata
 
 
 def subdir_path_factory(data: dict, addition: str):

--- a/bpod_rig/config/system_settings.py
+++ b/bpod_rig/config/system_settings.py
@@ -7,7 +7,7 @@ from typing import Annotated, Optional
 from pydantic import UUID4, Field, PastDate
 from pydantic_core import from_json
 
-from bpod_rig.config.base import ModelWithMetadata
+from bpod_rig.config.base import ModelWithMetadata, SettingsMetadata
 from bpod_rig.config.bpod_settings import BpodPaths
 from bpod_rig.defaults import (
     DEFAULT_CONFIG_DIR_NAME,
@@ -47,6 +47,12 @@ def system_path_factory(data: dict, addition: str) -> Path | None:
 
 
 class BpodDir(ModelWithMetadata):
+    """Bpod directory structure with required subdirectories.
+
+    Use the `create()` class method to construct instances with automatic
+    subdirectory path generation from the base directory.
+    """
+
     base_dir: Annotated[
         Path,
         Field(
@@ -62,52 +68,102 @@ class BpodDir(ModelWithMetadata):
     ]
 
     protocol_dir: Annotated[
-        Optional[Path],
+        Path,
         Field(
             title="Bpod Protocol Directory",
             description="Local directory where Bpod protocols are stored."
             " The Protocol explorer will list all valid protocols found"
             " in this directory.",
-            default_factory=lambda data: system_path_factory(
-                data, DEFAULT_PROTOCOL_DIR_NAME
-            ),
         ),
-    ] = None
+    ]
 
     data_dir: Annotated[
-        Optional[Path],
+        Path,
         Field(
             title="Bpod Data Directory",
             description="Local directory where data from protocol runs are stored.",
-            default_factory=lambda data: system_path_factory(
-                data, DEFAULT_DATA_DIR_NAME
-            ),
         ),
-    ] = None
+    ]
 
     base_config_dir: Annotated[
-        Optional[Path],
+        Path,
         Field(
             title="Bpod Configuration Directory",
             description="Local directory where Bpod configuration files are stored.",
-            default_factory=lambda data: system_path_factory(
-                data, DEFAULT_CONFIG_DIR_NAME
-            ),
         ),
-    ] = None
+    ]
 
     log_dir: Annotated[
         Optional[Path],
         Field(
             title="Bpod Log Directory",
             description="Local directory where Bpod logs are stored.",
-            # default_factory=lambda data: system_path_factory(
-            #     data,
-            #     DEFAULT_LOG_DIR_NAME
-            # ),
             # TODO: Add log folder to initial configuration; until then this is optional
         ),
     ] = None
+
+    @classmethod
+    def create(
+        cls,
+        base_dir: Path | str,
+        *,
+        protocol_dir: Path | str | None = None,
+        data_dir: Path | str | None = None,
+        base_config_dir: Path | str | None = None,
+        log_dir: Path | str | None = None,
+        username: str | None = None,
+        metadata: "SettingsMetadata | None" = None,
+    ) -> "BpodDir":
+        """Factory method to create BpodDir with automatic subdirectory paths.
+
+        This is the recommended way to create BpodDir instances. It automatically
+        generates subdirectory paths based on the base_dir if not explicitly provided.
+
+        Parameters
+        ----------
+        base_dir : Path | str
+            Base Bpod directory
+        protocol_dir : Path | str | None, optional
+            Override for protocol directory (default: base_dir/Protocols)
+        data_dir : Path | str | None, optional
+            Override for data directory (default: base_dir/Data)
+        base_config_dir : Path | str | None, optional
+            Override for config directory (default: base_dir/Config)
+        log_dir : Path | str | None, optional
+            Optional log directory
+        username : str | None, optional
+            Username for metadata
+        metadata : SettingsMetadata | None, optional
+            Pre-constructed metadata object
+
+        Returns
+        -------
+        BpodDir
+            Fully initialized BpodDir instance with all subdirectory paths populated
+
+        Examples
+        --------
+        >>> bpod_dir = BpodDir.create(base_dir="/home/user/Bpod")
+        >>> bpod_dir.protocol_dir
+        PosixPath('/home/user/Bpod/Protocols')
+        """
+        base_dir = Path(base_dir)
+        protocol_dir = Path(protocol_dir or base_dir / DEFAULT_PROTOCOL_DIR_NAME)
+        data_dir = Path(data_dir or base_dir / DEFAULT_DATA_DIR_NAME)
+        base_config_dir = Path(base_config_dir or base_dir / DEFAULT_CONFIG_DIR_NAME)
+        log_dir = Path(log_dir) if log_dir else None
+
+        metadata_object = metadata or SettingsMetadata()
+        metadata_object.username = username or metadata_object.username
+
+        return cls(
+            base_dir=base_dir,
+            protocol_dir=protocol_dir,
+            data_dir=data_dir,
+            base_config_dir=base_config_dir,
+            log_dir=log_dir,
+            metadata=metadata_object,
+        )
 
     def verify(self) -> bool:
         dir_verified = True

--- a/bpod_rig/config/system_settings.py
+++ b/bpod_rig/config/system_settings.py
@@ -7,15 +7,15 @@ from typing import Annotated, Optional
 from pydantic import UUID4, Field, PastDate
 from pydantic_core import from_json
 
-from bpod_rig.IO import json_handler
 from bpod_rig.config.base import ModelWithMetadata
 from bpod_rig.config.bpod_settings import BpodPaths
 from bpod_rig.defaults import (
-    DEFAULT_PROTOCOL_DIR_NAME,
-    DEFAULT_DATA_DIR_NAME,
     DEFAULT_CONFIG_DIR_NAME,
+    DEFAULT_DATA_DIR_NAME,
+    DEFAULT_PROTOCOL_DIR_NAME,
     SYSTEM_CONFIG_DIR,
 )
+from bpod_rig.IO import json_handler
 
 logger = logging.getLogger(__name__)
 

--- a/bpod_rig/config/system_settings.py
+++ b/bpod_rig/config/system_settings.py
@@ -20,32 +20,6 @@ from bpod_rig.IO import json_handler
 logger = logging.getLogger(__name__)
 
 
-def system_path_factory(data: dict, addition: str) -> Path | None:
-    """
-    Function to dynamically create SystemPath subpaths at validation time.
-
-    Function creates a path in the below form:
-        {base_dir}/[addition]
-    Path components in {} are retrieved from the dictionary of pre-validated data.
-
-    Parameters
-    ----------
-    data : dict
-        Dictionary containing all previously validated fields
-    addition : str
-        Addition to join to the end of the path.
-
-    Returns
-    -------
-    pathlib.Path
-        Combined path in above form.
-    """
-    if "base_dir" not in data:
-        return None
-
-    return data["base_dir"].joinpath(addition)
-
-
 class BpodDir(ModelWithMetadata):
     """Bpod directory structure with required subdirectories.
 
@@ -215,7 +189,7 @@ class SystemSettings(ModelWithMetadata):
             title="Current bpod-rig version",
             description="Currently installed version of the bpod-rig repository",
         ),
-    ] = "0.0.0"
+    ]
 
     last_update_check: Annotated[
         Optional[PastDate],
@@ -242,16 +216,15 @@ class SystemSettings(ModelWithMetadata):
             description="Whether or not the user has opted"
             " in to the phone-home telemetry.",
         ),
-    ] = False
+    ]
 
     debug: Annotated[
         bool,
         Field(
-            False,
             title="Debug Enabled",
             description="Set to True to enable debug information output.",
         ),
-    ] = False
+    ]
 
     paths: Annotated[
         BpodDir,

--- a/bpod_rig/config/system_settings.py
+++ b/bpod_rig/config/system_settings.py
@@ -153,16 +153,13 @@ class BpodDir(ModelWithMetadata):
         base_config_dir = Path(base_config_dir or base_dir / DEFAULT_CONFIG_DIR_NAME)
         log_dir = Path(log_dir) if log_dir else None
 
-        metadata_object = metadata or SettingsMetadata()
-        metadata_object.username = username or metadata_object.username
-
         return cls(
             base_dir=base_dir,
             protocol_dir=protocol_dir,
             data_dir=data_dir,
             base_config_dir=base_config_dir,
             log_dir=log_dir,
-            metadata=metadata_object,
+            metadata=metadata or SettingsMetadata(username=username or None),
         )
 
     def verify(self) -> bool:

--- a/bpod_rig/config/system_settings.py
+++ b/bpod_rig/config/system_settings.py
@@ -270,6 +270,60 @@ class SystemSettings(ModelWithMetadata):
         ),
     ] = None
 
+    @classmethod
+    def create(
+        cls,
+        paths: BpodDir,
+        *,
+        current_version: str = "0.0.0",
+        phone_home_opt_in: bool = False,
+        debug: bool = False,
+        bpod_dirs: Optional[list[BpodPaths]] = None,
+        username: str | None = None,
+        metadata: "SettingsMetadata | None" = None,
+    ) -> "SystemSettings":
+        """Factory method to create SystemSettings with automatic metadata handling.
+
+        This is the recommended way to create SystemSettings instances.
+
+        Parameters
+        ----------
+        paths : BpodDir
+            System paths configuration
+        current_version : str, optional
+            Currently installed version (default: "0.0.0")
+        phone_home_opt_in : bool, optional
+            Whether user opted into telemetry (default: False)
+        debug : bool, optional
+            Enable debug output (default: False)
+        bpod_dirs : Optional[list[BpodPaths]], optional
+            List of Bpod-specific paths (default: None)
+        username : str | None, optional
+            Username for metadata
+        metadata : SettingsMetadata | None, optional
+            Pre-constructed metadata object
+
+        Returns
+        -------
+        SystemSettings
+            Fully initialized SystemSettings instance
+
+        Examples
+        --------
+        >>> bpod_dir = BpodDir.create(base_dir="/home/user/Bpod")
+        >>> settings = SystemSettings.create(paths=bpod_dir, username="TestUser")
+        >>> settings.metadata.username
+        'TestUser'
+        """
+        return cls(
+            paths=paths,
+            current_version=current_version,
+            phone_home_opt_in=phone_home_opt_in,
+            debug=debug,
+            bpod_dirs=bpod_dirs,
+            metadata=metadata or SettingsMetadata(username=username),
+        )
+
     def update_modification_time(self):
         """Update time the SystemSettings object was modified.
 

--- a/bpod_rig/config/utils.py
+++ b/bpod_rig/config/utils.py
@@ -11,5 +11,5 @@ def init_system_configuration(bpod_dir: Path) -> SystemSettings:
         base_dir=bpod_dir,
     )
 
-    system_settings = SystemSettings(paths=system_paths)
+    system_settings = SystemSettings.create(paths=system_paths)
     return system_settings

--- a/bpod_rig/config/utils.py
+++ b/bpod_rig/config/utils.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def init_system_configuration(bpod_dir: Path) -> SystemSettings:
-    system_paths = BpodDir(
+    system_paths = BpodDir.create(
         base_dir=bpod_dir,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Austin Pauley", email = "pauley@psy.fsu.edu" },
     { name = "Florian Rau", email = "bimac@users.noreply.github.com" },
     { name = "Steven Smith", email = "steven@stevenlsmith.com" },
-    { name = "George Stuyt", email = "george.stuyt@gmail.com"}
+    { name = "George Stuyt", email = "george.stuyt@gmail.com" },
 ]
 requires-python = ">=3.10"
 dependencies = [
@@ -125,7 +125,6 @@ ignore = [
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
-fixable = []
 unfixable = []
 
 # Allow unused variables when underscore-prefixed.

--- a/tests/bpod_rig/IO/test_clio_io.py
+++ b/tests/bpod_rig/IO/test_clio_io.py
@@ -1,11 +1,12 @@
 import logging
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
-from unittest.mock import patch
-from bpod_rig.IO.cli_io import yes_no_prompt_cli_runner, prompt_for_path_cli_runner
+
+from bpod_rig.IO.cli_io import prompt_for_path_cli_runner, yes_no_prompt_cli_runner
 
 
 class TestCliIO:

--- a/tests/bpod_rig/IO/test_json_handler.py
+++ b/tests/bpod_rig/IO/test_json_handler.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+
 from bpod_rig.IO import json_handler
 
 JSON_STRING = '{"first_key":{"second_key": "1234"}}'

--- a/tests/bpod_rig/IO/test_startup.py
+++ b/tests/bpod_rig/IO/test_startup.py
@@ -1,8 +1,7 @@
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
 import pytest
-
 
 from bpod_rig.IO import startup
 

--- a/tests/bpod_rig/calibration/liquid/test_models.py
+++ b/tests/bpod_rig/calibration/liquid/test_models.py
@@ -14,7 +14,7 @@ class TestValveDataClass:
     def test_init_alias(self):
         # Test that alias works correctly
         # type checker may complain about this because of pydantic aliasing
-        assert ValveData(name="attrname").name == "attrname"  # noqa: Pydantic's validation aliases raises Unexpected Argument
+        assert ValveData(name="attrname").name == "attrname"  # pyright: ignore[reportCallIssue]
         assert ValveData(ValveName="aliasname").name == "aliasname"
 
     def test_add_measurement(self):

--- a/tests/bpod_rig/calibration/liquid/test_models.py
+++ b/tests/bpod_rig/calibration/liquid/test_models.py
@@ -1,7 +1,8 @@
-import pytest
 import urllib.request
 
-from bpod_rig.calibration.liquid import utils, populate_examples
+import pytest
+
+from bpod_rig.calibration.liquid import populate_examples, utils
 from bpod_rig.calibration.liquid.models import ValveData, ValveDataManager
 
 

--- a/tests/bpod_rig/calibration/liquid/test_pending_calibration.py
+++ b/tests/bpod_rig/calibration/liquid/test_pending_calibration.py
@@ -1,9 +1,7 @@
 import pytest
-
 from bpod_core.fsm import StateMachine
 
-from bpod_rig.calibration.liquid import pending_calibration
-from bpod_rig.calibration.liquid import utils, populate_examples
+from bpod_rig.calibration.liquid import pending_calibration, populate_examples, utils
 
 
 class TestPendingValve:

--- a/tests/bpod_rig/calibration/liquid/test_utils.py
+++ b/tests/bpod_rig/calibration/liquid/test_utils.py
@@ -1,4 +1,5 @@
 import datetime
+
 import pytest
 
 from bpod_rig.calibration.liquid import utils

--- a/tests/bpod_rig/config/test_models.py
+++ b/tests/bpod_rig/config/test_models.py
@@ -1,5 +1,5 @@
 import datetime
-import pathlib
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -67,7 +67,7 @@ class TestSystemPathsModel:
 
     def test_default_factory(self, paths):
         """Tests that the default directory paths are constructed correctly."""
-        sp = BpodDir(base_dir=paths["bpod_dir"])
+        sp = BpodDir.create(base_dir=paths["bpod_dir"])
         assert sp.data_dir == paths["data_dir"]
         assert sp.base_config_dir == paths["config_dir"]
         assert sp.protocol_dir == paths["protocol_dir"]
@@ -79,28 +79,30 @@ class TestSystemPathsModel:
         paths["protocol_dir"].mkdir(exist_ok=True)
         paths["config_dir"].mkdir(exist_ok=True)
 
-        sp = BpodDir(base_dir=paths["bpod_dir"], username="valid_username")
+        sp = BpodDir.create(base_dir=paths["bpod_dir"], username="valid_username")
 
-        # Does username get forwarded properly to the SettingsMatadata object
+        # Does username get forwarded properly to the SettingsMetadata object
         assert sp.metadata.username == "valid_username"
 
         # Does the SettingsMetadata object get properly forwarded
         md = SettingsMetadata()
-        sp2 = BpodDir(base_dir=paths["bpod_dir"], metadata=md, username="beepbop")
+        sp2 = BpodDir.create(
+            base_dir=paths["bpod_dir"], metadata=md, username="beepbop"
+        )
         assert sp2.metadata.username != "beepbop"
 
     def test_not_paths(self):
         """Tests that non-path inputs for directories raise validation errors."""
-        with pytest.raises(ValidationError):
-            BpodDir(base_dir=1234321)
+        with pytest.raises(TypeError):
+            BpodDir.create(base_dir=1234321) # type: ignore
 
-        sp = BpodDir(base_dir="/this/is/a/path")
-        assert isinstance(sp.base_dir, pathlib.Path)
+        sp = BpodDir.create(base_dir="/this/is/a/path")
+        assert isinstance(sp.base_dir, Path)
 
 
 class TestBpodPathsModel:
     @pytest.fixture
-    def paths(self, tmp_path):
+    def paths(self, tmp_path: Path):
         """Fixture to provide a common set of Bpod-specific path objects."""
         working_dir = tmp_path
         base_dir = working_dir.joinpath("Bpods")
@@ -117,23 +119,23 @@ class TestBpodPathsModel:
     def test_id_validation(self, paths):
         """Tests validation for the bpod_id field."""
         # No ID, fails validation
-        with pytest.raises(ValidationError):
-            BpodPaths(parent_dir=paths["bpod_dir"])
+        with pytest.raises(TypeError):
+            BpodPaths.create(parent_dir=paths["bpod_dir"])
 
         # ID is wrong type
         with pytest.raises(ValidationError):
-            BpodPaths(bpod_id=1234, parent_dir=paths["bpod_dir"])
+            BpodPaths.create(bpod_id=1234, parent_dir=paths["bpod_dir"])
 
         # No parent_dir
-        with pytest.raises(ValidationError):
-            BpodPaths(bpod_id=paths["bpod_id"])
+        with pytest.raises(TypeError):
+            BpodPaths.create(bpod_id=paths["bpod_id"])
 
-        bp = BpodPaths(bpod_id=paths["bpod_id"], parent_dir=paths["base_dir"])
+        bp = BpodPaths.create(bpod_id=paths["bpod_id"], parent_dir=paths["base_dir"])
         assert bp.bpod_id == paths["bpod_id"]
 
     def test_default_factory(self, paths):
         """Tests that the Bpod-specific paths are constructed correctly."""
-        bp = BpodPaths(bpod_id=paths["bpod_id"], parent_dir=paths["base_dir"])
+        bp = BpodPaths.create(bpod_id=paths["bpod_id"], parent_dir=paths["base_dir"])
         assert bp.unique_bpod_dir == paths["bpod_dir"]
         assert bp.parent_dir == paths["base_dir"]
         assert bp.calibration_dir == paths["calibration_dir"]
@@ -146,7 +148,7 @@ class TestSystemSettingsModel:
         """Fixture to provide a common set of path objects for tests."""
         working_dir = tmp_path
         bpod_dir = working_dir.joinpath("Bpod")
-        system_paths = BpodDir(base_dir=bpod_dir)
+        system_paths = BpodDir.create(base_dir=bpod_dir)
         return {"system_paths": system_paths}
 
     def test_default(self, paths):

--- a/tests/bpod_rig/config/test_models.py
+++ b/tests/bpod_rig/config/test_models.py
@@ -5,8 +5,8 @@ import pytest
 from pydantic import ValidationError
 
 from bpod_rig.config.base import SettingsMetadata
-from bpod_rig.config.system_settings import BpodDir, SystemSettings
 from bpod_rig.config.bpod_settings import BpodPaths
+from bpod_rig.config.system_settings import BpodDir, SystemSettings
 
 
 class TestMetadataModel:

--- a/tests/bpod_rig/config/test_models.py
+++ b/tests/bpod_rig/config/test_models.py
@@ -120,15 +120,15 @@ class TestBpodPathsModel:
         """Tests validation for the bpod_id field."""
         # No ID, fails validation
         with pytest.raises(TypeError):
-            BpodPaths.create(parent_dir=paths["bpod_dir"])
+            BpodPaths.create(parent_dir=paths["bpod_dir"])  # type: ignore
 
         # ID is wrong type
         with pytest.raises(ValidationError):
-            BpodPaths.create(bpod_id=1234, parent_dir=paths["bpod_dir"])
+            BpodPaths.create(bpod_id=1234, parent_dir=paths["bpod_dir"])  # type: ignore
 
         # No parent_dir
         with pytest.raises(TypeError):
-            BpodPaths.create(bpod_id=paths["bpod_id"])
+            BpodPaths.create(bpod_id=paths["bpod_id"])  # type: ignore
 
         bp = BpodPaths.create(bpod_id=paths["bpod_id"], parent_dir=paths["base_dir"])
         assert bp.bpod_id == paths["bpod_id"]
@@ -154,7 +154,7 @@ class TestSystemSettingsModel:
     def test_default(self, paths):
         """Tests that the default system settings are constructed correctly."""
         paths = paths["system_paths"]
-        settings = SystemSettings(paths=paths)
+        settings = SystemSettings.create(paths=paths)
 
         assert settings.current_version == "0.0.0"
         assert settings.last_update_check is None

--- a/tests/bpod_rig/config/test_models.py
+++ b/tests/bpod_rig/config/test_models.py
@@ -94,7 +94,7 @@ class TestSystemPathsModel:
     def test_not_paths(self):
         """Tests that non-path inputs for directories raise validation errors."""
         with pytest.raises(TypeError):
-            BpodDir.create(base_dir=1234321) # type: ignore
+            BpodDir.create(base_dir=1234321)  # type: ignore
 
         sp = BpodDir.create(base_dir="/this/is/a/path")
         assert isinstance(sp.base_dir, Path)

--- a/tests/bpod_rig/config/test_save_load.py
+++ b/tests/bpod_rig/config/test_save_load.py
@@ -25,7 +25,7 @@ def temp_config():
     bpod_dir = Path(tempfile.mkdtemp())
     config_dir = bpod_dir.joinpath("Config")
     sp = BpodDir.create(base_dir=bpod_dir)
-    ss = SystemSettings(paths=sp)
+    ss = SystemSettings.create(paths=sp)
     full_file_path = ss.paths.base_config_dir.joinpath("config.json")
 
     # Yield the created objects to the test function

--- a/tests/bpod_rig/config/test_save_load.py
+++ b/tests/bpod_rig/config/test_save_load.py
@@ -24,7 +24,7 @@ def temp_config():
     # --- Setup ---
     bpod_dir = Path(tempfile.mkdtemp())
     config_dir = bpod_dir.joinpath("Config")
-    sp = BpodDir(base_dir=bpod_dir)
+    sp = BpodDir.create(base_dir=bpod_dir)
     ss = SystemSettings(paths=sp)
     full_file_path = ss.paths.base_config_dir.joinpath("config.json")
 

--- a/tests/bpod_rig/config/test_save_load.py
+++ b/tests/bpod_rig/config/test_save_load.py
@@ -6,8 +6,8 @@ import pytest
 from pydantic_core import ValidationError
 
 from bpod_rig.config.system_settings import (
-    SystemSettings,
     BpodDir,
+    SystemSettings,
     load_system_configuration,
 )
 

--- a/tests/bpod_rig/examples/test_copy.py
+++ b/tests/bpod_rig/examples/test_copy.py
@@ -1,7 +1,9 @@
 import pathlib
-import pytest
 import shutil
 import tempfile
+
+import pytest
+
 from bpod_rig.examples import calibration, copy, settings
 
 


### PR DESCRIPTION
- Add `ruff check` and `pyright check` to the GitHub actions
- Fix all formatting and typing issues
- Refactor `config` Pydantic model creation to use `.create` factory method
- Bugfix: `bpod-core` `0.1.0a10` changed the method for running a state machine, which the auto PR didn't pick up because it didn't have type checking.

The changes to the `pydantic` models involve moving generation to a `.create()` method. This makes the field generation easier to follow and maintain. The type checking indicated that the usage of the fields versus their annotations/`Field` were not not expected, largely following from the fact that they were marked `Optional` while the `default_factory` ensured they would be filled by using information used to generate other fields.

Now, we can describe the model precisely as its final state is meant to be, while keeping generation logic with intermediate steps in `.create()`.