### PR TITLE
[WIP] More Robust Logging Configuration

### DIFF
--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -133,7 +133,7 @@ def main():
         logger.error("No valid Bpod directory! Shutting down.")
         raise
 
-    logger.swap_stream(system_paths.log_dir)
+    logger.swap_stream(system_paths.log_dir)  # type: ignore
 
     initial_system_config = utils.init_system_configuration(bpod_path)
     user_config_path = initial_system_config.save_system_configuration()  # noqa: F841

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -2,6 +2,7 @@
 
 import logging
 from logging.config import dictConfig
+from typing import cast
 
 from pydantic import ValidationError
 
@@ -20,7 +21,7 @@ if DEBUG:
 # Set up logging here
 dictConfig(LOGGING_CONFIG)
 logging.setLoggerClass(BpodLogger)
-logger = logging.getLogger(__name__)
+logger: BpodLogger = cast(BpodLogger, logging.getLogger(__name__))
 
 
 def main():
@@ -133,7 +134,7 @@ def main():
         logger.error("No valid Bpod directory! Shutting down.")
         raise
 
-    logger.swap_stream(system_paths.log_dir)  # type: ignore
+    logger.swap_stream(system_paths.log_dir)
 
     initial_system_config = utils.init_system_configuration(bpod_path)
     user_config_path = initial_system_config.save_system_configuration()  # noqa: F841

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -1,6 +1,6 @@
 """main entry point for bpod-rig."""
-
 import logging
+from logging.config import dictConfig
 
 from pydantic import ValidationError
 
@@ -8,10 +8,12 @@ from bpod_rig.config import utils
 from bpod_rig.config.system_settings import BpodDir
 from bpod_rig.defaults import DEFAULT_BPOD_PATH, SYSTEM_CONFIG_DIR, SYSTEM_CONFIG_FILE
 from bpod_rig.IO import cli_io, startup
+from bpod_rig.log import LOGGING_CONFIG, BpodLogger
 
-logging.basicConfig(level=logging.DEBUG)
+# Set up logging here
+dictConfig(LOGGING_CONFIG)
+logging.setLoggerClass(BpodLogger)
 logger = logging.getLogger(__name__)
-
 
 def main():
     ### Everything below is subject to change and is for testing purposes only

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -10,16 +10,13 @@ from bpod_rig.config import utils
 from bpod_rig.config.system_settings import BpodDir
 from bpod_rig.defaults import DEFAULT_BPOD_PATH, SYSTEM_CONFIG_DIR, SYSTEM_CONFIG_FILE
 from bpod_rig.IO import cli_io, startup
-from bpod_rig.log import LOGGING_CONFIG, BpodLogger
+from bpod_rig.log import LOGGING_CONFIG, BpodLogger, get_log_config
 
 DEBUG = True
 
-if DEBUG:
-    LOGGING_CONFIG["handlers"]["stdout"]["level"] = "DEBUG"
-    LOGGING_CONFIG["handlers"]["stdout"]["filters"] = []
-
 # Set up logging here
-dictConfig(LOGGING_CONFIG)
+logging_config = get_log_config(DEBUG)
+dictConfig(logging_config)
 logging.setLoggerClass(BpodLogger)
 logger: BpodLogger = cast(BpodLogger, logging.getLogger(__name__))
 

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -11,6 +11,12 @@ from bpod_rig.defaults import DEFAULT_BPOD_PATH, SYSTEM_CONFIG_DIR, SYSTEM_CONFI
 from bpod_rig.IO import cli_io, startup
 from bpod_rig.log import LOGGING_CONFIG, BpodLogger
 
+DEBUG = True
+
+if DEBUG:
+    LOGGING_CONFIG["handlers"]["stdout"]["level"] = "DEBUG"
+    LOGGING_CONFIG["handlers"]["stdout"]["filters"] = []
+
 # Set up logging here
 dictConfig(LOGGING_CONFIG)
 logging.setLoggerClass(BpodLogger)
@@ -126,6 +132,8 @@ def main():
     else:
         logger.error("No valid Bpod directory! Shutting down.")
         raise
+
+    logger.swap_stream(system_paths.log_dir)
 
     initial_system_config = utils.init_system_configuration(bpod_path)
     user_config_path = initial_system_config.save_system_configuration()  # noqa: F841

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -29,8 +29,8 @@ def main():
     ### Has Bpod been initialized on this system before? ###
     system_initialized = startup.check_system_is_initialized()
     if not system_initialized:
-        logging.info("Initializing Bpod Rig...")
-        logging.debug(
+        logger.info("Initializing Bpod Rig...")
+        logger.debug(
             "System is not initialized. Creating system config dir [%s]",
             SYSTEM_CONFIG_DIR,
         )
@@ -110,7 +110,7 @@ def main():
     if reinitialize or not system_initialized:
         # We will (re) create the Bpod directories if the system isn't initialized
         # or something went wrong and we need to reinitialize
-        logging.info("Initializing Bpod directory at %s", bpod_path)
+        logger.info("Initializing Bpod directory at %s", bpod_path)
         bpod_path = startup.create_default_directories(bpod_path)
         bpod_dir_verified = True
 
@@ -122,7 +122,7 @@ def main():
             startup.copy_default_files(bpod_path)
 
     if bpod_dir_verified:
-        logging.debug("System paths at %s verified", bpod_path)
+        logger.debug("System paths at %s verified", bpod_path)
     else:
         logger.error("No valid Bpod directory! Shutting down.")
         raise

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -10,7 +10,7 @@ from bpod_rig.config import utils
 from bpod_rig.config.system_settings import BpodDir
 from bpod_rig.defaults import DEFAULT_BPOD_PATH, SYSTEM_CONFIG_DIR, SYSTEM_CONFIG_FILE
 from bpod_rig.IO import cli_io, startup
-from bpod_rig.log import LOGGING_CONFIG, BpodLogger, get_log_config
+from bpod_rig.log import BpodLogger, get_log_config
 
 DEBUG = True
 

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -1,4 +1,5 @@
 """main entry point for bpod-rig."""
+
 import logging
 from logging.config import dictConfig
 
@@ -14,6 +15,7 @@ from bpod_rig.log import LOGGING_CONFIG, BpodLogger
 dictConfig(LOGGING_CONFIG)
 logging.setLoggerClass(BpodLogger)
 logger = logging.getLogger(__name__)
+
 
 def main():
     ### Everything below is subject to change and is for testing purposes only

--- a/bpod_rig/config/system_settings.py
+++ b/bpod_rig/config/system_settings.py
@@ -12,6 +12,7 @@ from bpod_rig.config.bpod_settings import BpodPaths
 from bpod_rig.defaults import (
     DEFAULT_CONFIG_DIR_NAME,
     DEFAULT_DATA_DIR_NAME,
+    DEFAULT_LOG_DIR_NAME,
     DEFAULT_PROTOCOL_DIR_NAME,
     SYSTEM_CONFIG_DIR,
 )
@@ -68,13 +69,12 @@ class BpodDir(ModelWithMetadata):
     ]
 
     log_dir: Annotated[
-        Optional[Path],
+        Path,
         Field(
             title="Bpod Log Directory",
             description="Local directory where Bpod logs are stored.",
-            # TODO: Add log folder to initial configuration; until then this is optional
         ),
-    ] = None
+    ]
 
     @classmethod
     def create(
@@ -125,7 +125,7 @@ class BpodDir(ModelWithMetadata):
         protocol_dir = Path(protocol_dir or base_dir / DEFAULT_PROTOCOL_DIR_NAME)
         data_dir = Path(data_dir or base_dir / DEFAULT_DATA_DIR_NAME)
         base_config_dir = Path(base_config_dir or base_dir / DEFAULT_CONFIG_DIR_NAME)
-        log_dir = Path(log_dir) if log_dir else None
+        log_dir = Path(log_dir or base_dir / DEFAULT_LOG_DIR_NAME)
 
         return cls(
             base_dir=base_dir,

--- a/bpod_rig/defaults.py
+++ b/bpod_rig/defaults.py
@@ -18,4 +18,3 @@ DEFAULT_BPOD_PATH = platformdirs.user_documents_path() / DEFAULT_DIR_NAME
 # Logging
 TIME_FORMAT = "%Y-%m-%d-%H-%M-%S"
 LOGFILE_PREFIX = "bpod"
-

--- a/bpod_rig/defaults.py
+++ b/bpod_rig/defaults.py
@@ -14,3 +14,8 @@ DEFAULT_LOG_DIR_NAME = "Logs"
 SYSTEM_CONFIG_DIR = platformdirs.user_config_path(DEFAULT_DIR_NAME, "sanworks")
 SYSTEM_CONFIG_FILE = SYSTEM_CONFIG_DIR / "config.json"
 DEFAULT_BPOD_PATH = platformdirs.user_documents_path() / DEFAULT_DIR_NAME
+
+# Logging
+TIME_FORMAT = "%Y-%m-%d-%H-%M-%S"
+LOGFILE_PREFIX = "bpod"
+

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from bpod_rig.defaults import TIME_FORMAT, LOGFILE_PREFIX
+from bpod_rig.defaults import LOGFILE_PREFIX, TIME_FORMAT
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -76,7 +76,9 @@ class DynamicFileHandler(logging.FileHandler):
     """
 
     def __init__(self):
-        self.temp_stream = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log")  # noqa: SIM115
+        self.temp_stream = tempfile.NamedTemporaryFile(  # noqa: SIM115
+            mode="w", delete=False, suffix=".log"
+        )
         self.log_dir: Path | None = None
         self.new_filepath: Path | None = None
         super().__init__(self.temp_stream.name)
@@ -101,7 +103,6 @@ class DynamicFileHandler(logging.FileHandler):
         -------
             None
         """
-
         if isinstance(logging_dir, str):
             logging_dir = Path(logging_dir)
 
@@ -118,18 +119,19 @@ class DynamicFileHandler(logging.FileHandler):
 
         self.close()
         # Close current file stream and flush buffer
-        shutil.copyfile(self.temp_stream.name, self.new_filepath)
-        # Copy and rename the temp logfile
 
-        self.stream = open(self.new_filepath, "a")
-        # Open new stream and set to current stream
+        if self.new_filepath is not None:
+            shutil.copyfile(self.temp_stream.name, self.new_filepath)
+            # Copy and rename the temp logfile
+            self.stream = open(self.new_filepath, "a")  # NOQA SIM115
+            # Open new stream and set to current stream
 
         self.temp_stream.close()  # Close the tempfile which should delete it
 
-
     def _set_new_filepath(self) -> None:
         current_dt = datetime.datetime.now().strftime(TIME_FORMAT)
-        self.new_filepath = self.log_dir / f"{LOGFILE_PREFIX}-{current_dt}.log"
+        if self.log_dir is not None:
+            self.new_filepath = self.log_dir / f"{LOGFILE_PREFIX}-{current_dt}.log"
 
 
 class BpodLogger(logging.Logger):
@@ -154,4 +156,6 @@ class BpodLogger(logging.Logger):
         if self.file_handler:
             self.file_handler.swap_stream(logging_dir)
         else:
-            raise AttributeError("There is no DynamicFileHandler instance present for this logger!")
+            raise AttributeError(
+                "There is no DynamicFileHandler instance present for this logger!"
+            )

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -106,11 +106,11 @@ class DynamicFileHandler(logging.FileHandler):
             mode="w", delete=False, suffix=".log"
         )
         self.log_dir: Path | None = None
-        self.new_filepath: Path | None = None
+        self.new_filename: str | None = None
         self.logger: logging.Logger | None = None
         super().__init__(self.temp_stream.name)
 
-        self._set_new_filepath()
+        self._generate_filename()
         # Determine what our new logfile name should be
 
     def _cleanup(self) -> None:
@@ -154,25 +154,25 @@ class DynamicFileHandler(logging.FileHandler):
         self.close()
         # Close current file stream and flush buffer
 
-        if self.new_filepath is not None:
-            shutil.copyfile(self.temp_stream.name, self.new_filepath)
+        if self.new_filename is not None:
+            new_logfile_path = self.log_dir / self.new_filename
+            shutil.copyfile(self.temp_stream.name, new_logfile_path)
             self.logger.debug(
-                "Copying and renaming temp logfile to %s", self.new_filepath
+                "Copying and renaming temp logfile to %s", new_logfile_path
             )
             # Copy and rename the temp logfile
-            self.stream = open(self.new_filepath, "a")  # NOQA SIM115
+            self.stream = open(new_logfile_path, "a")  # NOQA SIM115
             self.logger.debug("Opening new file stream")
             # Open new stream and set to current stream
 
         self.temp_stream.close()  # Close the tempfile which should delete it
         self.logger.debug("Closing temp file stream")
 
-    def _set_new_filepath(self) -> None:
+    def _generate_filename(self) -> None:
         current_dt = datetime.datetime.now().strftime(TIME_FORMAT)
-        if self.log_dir is not None:
-            self.new_filepath = self.log_dir / f"{LOGFILE_PREFIX}-{current_dt}.log"
-            if self.logger is not None:
-                self.logger.debug("New logfile path set to: %s", self.new_filepath)
+        self.new_filename = f"{LOGFILE_PREFIX}-{current_dt}.log"
+        if self.logger is not None:
+            self.logger.debug("New logfile path set to: %s", self.new_filename)
 
 
 class BpodLogger(logging.Logger):

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -54,6 +54,7 @@ LOGGING_CONFIG = {
     },
 }
 
+
 def get_log_config(debug: bool = False) -> dict:
     """Factory function to get logging configuration.
 
@@ -74,6 +75,7 @@ def get_log_config(debug: bool = False) -> dict:
         LOGGING_CONFIG["handlers"]["stdout"]["filters"] = ""
 
     return LOGGING_CONFIG
+
 
 def stdout_filter():
     def filter(lf: logging.LogRecord) -> bool:  # noqa: A001
@@ -148,7 +150,6 @@ class DynamicFileHandler(logging.FileHandler):
         self.logger.debug("Logging directory set to: %s", self.log_dir)
         if self.log_dir is None:
             raise TypeError("Logging directory is not specified!")
-
 
         self.close()
         # Close current file stream and flush buffer

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from bpod_rig.defaults import LOGFILE_PREFIX, TIME_FORMAT
 
+logger = logging.getLogger(__name__)
+
 LOGGING_CONFIG = {
     "version": 1,
     "disable_existing_loggers": True,
@@ -76,6 +78,7 @@ class DynamicFileHandler(logging.FileHandler):
     """
 
     def __init__(self):
+        logger.debug("Opening temporary file stream")
         self.temp_stream = tempfile.NamedTemporaryFile(  # noqa: SIM115
             mode="w", delete=False, suffix=".log"
         )
@@ -110,7 +113,7 @@ class DynamicFileHandler(logging.FileHandler):
             raise FileNotFoundError(f"Logging directory {logging_dir} does not exist!")
 
         self.log_dir = logging_dir
-
+        logger.debug("Logging directory set to: %s", self.log_dir)
         if self.log_dir is None:
             raise TypeError("Logging directory is not specified!")
 
@@ -132,6 +135,7 @@ class DynamicFileHandler(logging.FileHandler):
         current_dt = datetime.datetime.now().strftime(TIME_FORMAT)
         if self.log_dir is not None:
             self.new_filepath = self.log_dir / f"{LOGFILE_PREFIX}-{current_dt}.log"
+            logger.debug("New logfile path set to: %s", self.new_filepath)
 
 
 class BpodLogger(logging.Logger):

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from bpod_rig.defaults import LOGFILE_PREFIX, TIME_FORMAT
 
-logger = logging.getLogger(__name__)
+# logger = logging.getLogger(__name__)
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -107,6 +107,9 @@ class DynamicFileHandler(logging.FileHandler):
         -------
             None
         """
+
+        self.logger = logging.getLogger("temp_file_handler")
+
         if isinstance(logging_dir, str):
             logging_dir = Path(logging_dir)
 
@@ -114,7 +117,7 @@ class DynamicFileHandler(logging.FileHandler):
             raise FileNotFoundError(f"Logging directory {logging_dir} does not exist!")
 
         self.log_dir = logging_dir
-        logger.debug("Logging directory set to: %s", self.log_dir)
+        self.logger.debug("Logging directory set to: %s", self.log_dir)
         if self.log_dir is None:
             raise TypeError("Logging directory is not specified!")
 
@@ -136,7 +139,7 @@ class DynamicFileHandler(logging.FileHandler):
         current_dt = datetime.datetime.now().strftime(TIME_FORMAT)
         if self.log_dir is not None:
             self.new_filepath = self.log_dir / f"{LOGFILE_PREFIX}-{current_dt}.log"
-            logger.debug("New logfile path set to: %s", self.new_filepath)
+            self.logger.debug("New logfile path set to: %s", self.new_filepath)
 
 
 class BpodLogger(logging.Logger):

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -3,7 +3,6 @@ import logging
 import shutil
 import tempfile
 from pathlib import Path
-from logging.config import dictConfig
 
 LOGGING_CONFIG = {
     'version': 1,
@@ -63,7 +62,7 @@ LOGGING_CONFIG = {
     }
 
 def stdout_filter():
-    def filter(lf: logging.LogRecord) -> bool:
+    def filter(lf: logging.LogRecord) -> bool:  # noqa: A001
         return logging.ERROR > lf.levelno >= logging.INFO
         # If 40 > lf.levelno >= 20
     return filter
@@ -76,6 +75,24 @@ class DynamicFileHandler(logging.FileHandler):
     DynamicFileHandler creates a temporary file to output the initialization logging
     to. Once the logging directory is known, the output stream is swapped and the
     contents of the temp log copied over.
+
+    Currently, the naming convention for the currently used logfile will be:
+        current-[date].log
+
+    The DynamicFileHandler will automatically handle logfile naming, renaming, and
+    selection using the criteria below.
+
+    When swapping from the tempfile to a known logging directory, the DynamicFileHandler
+    will choose the correct logfile by making several checks within the new self.log_dir
+    directory:
+        1) If no logfiles exist, a new logfile named current-[date].log is used
+        2) If there are existing logfiles, but none contain the keyword `current`, a
+        new logfile named current-[date].log is created
+        3) If there is a logfile containing the keyword `current`, but the date is not
+        today, the keyword `current` is removed from the name, leaving just
+        [old_date].log Then, a new logfile named current-[date].log is created
+        4) If there is a logfile with the name current-[date].log and [date] is today,
+        that logfile is used
     """
 
     def __init__(self):
@@ -91,6 +108,21 @@ class DynamicFileHandler(logging.FileHandler):
         self.stream.close()
 
     def swap_stream(self, logging_dir: Path | str):
+        """Swaps the temporary stream for a file in the logging_dir directory.
+
+        This function takes a path to a logging directory, gets the new filename,
+        swaps the filestream for the FileStreamHandler, copies any log entries over, and
+        closes all the dangling streams.
+
+        Parameters
+        ----------
+        logging_dir : Path | str
+            Directory to store logfiles in
+
+        Returns
+        -------
+            None
+        """
         if isinstance(logging_dir, str):
             logging_dir = Path(logging_dir)
 
@@ -98,7 +130,7 @@ class DynamicFileHandler(logging.FileHandler):
         self._get_new_filepath()
         # Determine what our new logfile name should be
 
-        old_stream = self.setStream(open(self.new_filepath, 'a'))
+        old_stream = self.setStream(open(self.new_filepath, 'a'))  # noqa: SIM115
         # Let's do this first so any remaining data is flushed from the stream
         # Set the stream to our new stream, which returns the old stream
 
@@ -110,6 +142,16 @@ class DynamicFileHandler(logging.FileHandler):
 
 
     def _get_new_filepath(self) -> None:
+        """Function to help determine new logfile path.
+
+        This function uses the current logfile, determines if the date in the name is
+        old, triggers the file rename (if needed) and sets the self.new_filepath
+        parameter
+
+        Returns
+        -------
+            None
+        """
         self._find_current_logfile()  # Is there a file with pattern "current-[date].log"
 
         if self.current_logfile is not None:
@@ -125,7 +167,8 @@ class DynamicFileHandler(logging.FileHandler):
             self.new_filepath = self._new_logfile_path()
 
 
-    def _find_current_logfile(self):
+    def _find_current_logfile(self) -> None:
+        """Checks self.log_dir for logfile matching the `current-[date].log` format."""
         logfiles = self.log_dir.glob('*.log')
         current_logfile = [file for file in logfiles if "current" in file.name]
         if len(current_logfile) == 0:
@@ -136,7 +179,8 @@ class DynamicFileHandler(logging.FileHandler):
             self.current_logfile = current_logfile[0]
 
 
-    def _current_file_from_past(self):
+    def _current_file_from_past(self) -> bool:
+        """Determines whether the date in a filename is from the past."""
         date = self.current_logfile.stem.split("_")[1]
         file_date = datetime.date.fromisoformat(date)
         today_date = datetime.date.today()
@@ -144,7 +188,7 @@ class DynamicFileHandler(logging.FileHandler):
         return file_date < today_date
 
 
-    def _rename_current_logfile(self):
+    def _rename_current_logfile(self) -> None:
         """Removes 'current' from logfile by renaming.
 
         Takes the logfile with the name format "current-[date].log" and renames it
@@ -161,3 +205,28 @@ class DynamicFileHandler(logging.FileHandler):
 
     def _new_logfile_path(self) -> Path:
         return self.log_dir.joinpath(f"current-{datetime.date.today()}.log")
+
+
+class BpodLogger(logging.Logger):
+    """Bpod logger class.
+
+    Small wrapper class to bring the "swap_stream" functionality of the
+    DynamicFileHandler to the top level if it is present in the root logger handlers
+    property.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.file_handler: DynamicFileHandler | None = None
+
+        for handler in self.root.handlers:
+            if isinstance(handler, DynamicFileHandler):
+                self.file_handler = handler
+
+    def swap_stream(self, logging_dir: Path | str):
+        if self.file_handler:
+            self.file_handler.swap_stream(logging_dir)
+        else:
+            self.error("There is no DynamicFileHandler instance present for this logger!")

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -68,13 +68,13 @@ class DynamicFileHandler(logging.FileHandler):
 
     When bpod-rig is initialized, the logging directory is not known.
     DynamicFileHandler creates a temporary file to output the initialization logging
-    to. Once the logging directory is known, the output stream is swapped and the
-    contents of the temp log copied over.
+    to. Once the logging directory is known, the contents of the temp log are copied
+    over to the logging directory, and the output stream is swapped.
 
     Logfiles are created with each launch of bpod-rig. Logfiles are named based on
-    the current ISO 8601-formatted date and time and a prefix.
+    the current date and time with a prefix:
 
-        e.g.: bpod-YYYY-MM-DDTHH:MM:SS.log
+        bpod-YYYY-MM-DD-HH-MM-SS.log
 
     """
 
@@ -97,9 +97,12 @@ class DynamicFileHandler(logging.FileHandler):
     def swap_stream(self, logging_dir: Path | str):
         """Swaps the temporary stream for a file in the logging_dir directory.
 
-        This function takes a path to a logging directory, gets the new filename,
-        swaps the filestream for the FileStreamHandler, copies any log entries over, and
-        closes all the dangling streams.
+        This function has multiple steps:
+            1) checks for the existence of the logging directory
+            2) stops the current stream to flush the buffer
+            3) copies and renames the temporary logfile
+            4) opens and sets the new FileHandler stream
+            5) closes the temporary stream
 
         Parameters
         ----------

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -54,6 +54,26 @@ LOGGING_CONFIG = {
     },
 }
 
+def get_log_config(debug: bool = False) -> dict:
+    """Factory function to get logging configuration.
+
+    If debug is True, DEBUG messages are passed through to stdout
+
+    Parameters
+    ----------
+    debug : bool (optional)
+        Flag to enable/disable debug messages in stdout
+
+    Returns
+    -------
+        LOGGING_CONFIG: dict
+
+    """
+    if debug:
+        LOGGING_CONFIG["handlers"]["stdout"]["level"] = "DEBUG"
+        LOGGING_CONFIG["handlers"]["stdout"]["filters"] = ""
+
+    return LOGGING_CONFIG
 
 def stdout_filter():
     def filter(lf: logging.LogRecord) -> bool:  # noqa: A001

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -157,12 +157,11 @@ class DynamicFileHandler(logging.FileHandler):
         if self.new_filename is not None:
             new_logfile_path = self.log_dir / self.new_filename
             shutil.copyfile(self.temp_stream.name, new_logfile_path)
-            self.logger.debug(
-                "Copying and renaming temp logfile to %s", new_logfile_path
-            )
+
             # Copy and rename the temp logfile
             self.stream = open(new_logfile_path, "a")  # NOQA SIM115
             self.logger.debug("Opening new file stream")
+            self.logger.debug("Temp logfile copied and renamed to %s", new_logfile_path)
             # Open new stream and set to current stream
 
         self.temp_stream.close()  # Close the tempfile which should delete it

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -1,0 +1,133 @@
+import datetime
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from logging.config import dictConfig
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters':
+        {
+        'time':
+            {
+            'format': '%(asctime)s - [%(levelname)s] %(name)s: %(message)s',
+            'datefmt': '%H:%M:%S',
+            },
+        'notime':
+            {
+                'format': '[%(levelname)s] %(name)s: %(message)s',
+            }
+        },
+    'handlers':
+        {
+        'stdout':
+            {
+            'class': 'logging.StreamHandler',
+            'formatter': 'notime',
+            'stream': 'ext://sys.stdout'
+            },
+        'stderr':
+            {
+            'class': 'logging.StreamHandler',
+            'formatter': 'time',
+            'stream': 'ext://sys.stderr'
+            }
+        },
+    'loggers':
+        {
+        '':
+            {
+            'handlers': ['stdout'],
+            'level': 'DEBUG',
+            'propagate': True
+            }
+        }
+    }
+
+class DynamicFileHandler(logging.FileHandler):
+    """ Dynamic log file handler
+
+    When bpod-rig is initialized, the logging directory is not known.
+    DynamicFileHandler creates a temporary file to output the initialization logging
+    to. Once the logging directory is known, the output stream is swapped and the
+    contents of the temp log copied over.
+
+    """
+    def __init__(self):
+        self.temp_stream = tempfile.NamedTemporaryFile()
+        self.log_dir: Path | None = None
+        self.current_logfile: Path | None = None
+        self.new_filepath: Path | None = None
+        super().__init__(self.temp_stream.name)
+
+
+    def swap_stream(self, logging_dir: Path):
+        self.log_dir = logging_dir
+        self._get_new_filepath()
+        # Determine what our new logfile name should be
+
+        old_stream = self.setStream(open(self.new_filepath, 'a'))
+        # Let's do this first so any remaining data is flushed from the stream
+        # Set the stream to our new stream, which returns the old stream
+
+        shutil.copyfile(self.temp_stream.name, self.new_filepath)
+        # Copy contents of temporary logfile into our new logfile
+
+        old_stream.close() # Close the old filestream
+        self.temp_stream.close() # Close the tempfile which should delete it
+
+
+    def _get_new_filepath(self) -> None:
+        self._find_current_logfile()  # Is there a file with pattern "current-[date].log"
+
+        if self.current_logfile is not None:
+            if self._current_file_from_past():
+                # Most recent logfile is old, rename it and create new "current"
+                self._rename_current_logfile()
+                self.new_filepath = self._new_logfile_path()
+            else:
+                # Most recent logfile is current
+                self.new_filepath = self.current_logfile
+        else:
+            # Catchall for a new log directory
+            self.new_filepath = self._new_logfile_path()
+
+
+    def _find_current_logfile(self):
+        logfiles = self.log_dir.glob('*.log')
+        current_logfile = [file for file in logfiles if "current" in file.name]
+        if len(current_logfile) == 0:
+            # There is no current logfile
+            self.current_logfile = None
+        else:
+            # logfile with 'current' in name found
+            self.current_logfile = current_logfile[0]
+
+
+    def _current_file_from_past(self):
+        date = self.current_logfile.stem.split("_")[1]
+        file_date = datetime.date.fromisoformat(date)
+        today_date = datetime.date.today()
+
+        return file_date < today_date
+
+
+    def _rename_current_logfile(self):
+        """Removes 'current' from logfile by renaming
+
+        Takes the logfile with the name format "current-[date].log" and renames it
+        to "[date].log"
+
+        Returns
+        -------
+            None
+        """
+        date = self.current_logfile.stem.split("_")[1]
+        new_name = self.current_logfile.with_stem(date)
+        self.current_logfile.rename(new_name)
+
+
+    def _new_logfile_path(self) -> Path:
+        return self.log_dir.joinpath(f"current-{datetime.date.today()}.log")

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 from logging.config import dictConfig
 
-LOGGING = {
+LOGGING_CONFIG = {
     'version': 1,
     'disable_existing_loggers': True,
     'formatters':
@@ -20,50 +20,80 @@ LOGGING = {
                 'format': '[%(levelname)s] %(name)s: %(message)s',
             }
         },
+    'filters':
+        {
+            'stdout_filter':
+                {
+                    '()': 'bpod_rig.log.stdout_filter',
+                }
+        },
     'handlers':
         {
         'stdout':
             {
             'class': 'logging.StreamHandler',
+            'level': 'INFO',
             'formatter': 'notime',
+            'filters': ['stdout_filter'],
             'stream': 'ext://sys.stdout'
             },
         'stderr':
             {
             'class': 'logging.StreamHandler',
+            'level': 'ERROR',
             'formatter': 'time',
             'stream': 'ext://sys.stderr'
+            },
+        'dynamic_file':
+            {
+                'class': 'bpod_rig.log.DynamicFileHandler',
+                'formatter': 'time',
+
             }
         },
     'loggers':
         {
         '':
             {
-            'handlers': ['stdout'],
+            'handlers': ['stdout', 'stderr', 'dynamic_file'],
             'level': 'DEBUG',
             'propagate': True
             }
         }
     }
 
+def stdout_filter():
+    def filter(lf: logging.LogRecord) -> bool:
+        return logging.ERROR > lf.levelno >= logging.INFO
+        # If 40 > lf.levelno >= 20
+    return filter
+
+
 class DynamicFileHandler(logging.FileHandler):
-    """ Dynamic log file handler
+    """Dynamic log file handler.
 
     When bpod-rig is initialized, the logging directory is not known.
     DynamicFileHandler creates a temporary file to output the initialization logging
     to. Once the logging directory is known, the output stream is swapped and the
     contents of the temp log copied over.
-
     """
+
     def __init__(self):
-        self.temp_stream = tempfile.NamedTemporaryFile()
+        self.temp_stream = tempfile.NamedTemporaryFile()  # noqa: SIM115
         self.log_dir: Path | None = None
         self.current_logfile: Path | None = None
         self.new_filepath: Path | None = None
         super().__init__(self.temp_stream.name)
 
 
-    def swap_stream(self, logging_dir: Path):
+    def __del__(self) -> None:
+        self.temp_stream.close()
+        self.stream.close()
+
+    def swap_stream(self, logging_dir: Path | str):
+        if isinstance(logging_dir, str):
+            logging_dir = Path(logging_dir)
+
         self.log_dir = logging_dir
         self._get_new_filepath()
         # Determine what our new logfile name should be
@@ -115,7 +145,7 @@ class DynamicFileHandler(logging.FileHandler):
 
 
     def _rename_current_logfile(self):
-        """Removes 'current' from logfile by renaming
+        """Removes 'current' from logfile by renaming.
 
         Takes the logfile with the name format "current-[date].log" and renames it
         to "[date].log"

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -78,7 +78,6 @@ class DynamicFileHandler(logging.FileHandler):
     """
 
     def __init__(self):
-        logger.debug("Opening temporary file stream")
         self.temp_stream = tempfile.NamedTemporaryFile(  # noqa: SIM115
             mode="w", delete=False, suffix=".log"
         )
@@ -87,8 +86,10 @@ class DynamicFileHandler(logging.FileHandler):
         super().__init__(self.temp_stream.name)
 
     def __del__(self) -> None:
-        self.temp_stream.close()
-        self.close()
+        if self.temp_stream is not None:
+            self.temp_stream.close()
+        if self.stream is not None:
+            self.close()
 
     def swap_stream(self, logging_dir: Path | str):
         """Swaps the temporary stream for a file in the logging_dir directory.

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -88,6 +88,9 @@ class DynamicFileHandler(logging.FileHandler):
         self.logger: logging.Logger | None = None
         super().__init__(self.temp_stream.name)
 
+        self._set_new_filepath()
+        # Determine what our new logfile name should be
+
     def _cleanup(self) -> None:
         if self.temp_stream is not None:
             self.temp_stream.close()
@@ -126,8 +129,6 @@ class DynamicFileHandler(logging.FileHandler):
         if self.log_dir is None:
             raise TypeError("Logging directory is not specified!")
 
-        self._set_new_filepath()
-        # Determine what our new logfile name should be
 
         self.close()
         # Close current file stream and flush buffer

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -5,66 +5,56 @@ import tempfile
 from pathlib import Path
 
 LOGGING_CONFIG = {
-    'version': 1,
-    'disable_existing_loggers': True,
-    'formatters':
-        {
-        'time':
-            {
-            'format': '%(asctime)s - [%(levelname)s] %(name)s: %(message)s',
-            'datefmt': '%H:%M:%S',
-            },
-        'notime':
-            {
-                'format': '[%(levelname)s] %(name)s: %(message)s',
-            }
+    "version": 1,
+    "disable_existing_loggers": True,
+    "formatters": {
+        "time": {
+            "format": "%(asctime)s - [%(levelname)s] %(name)s: %(message)s",
+            "datefmt": "%H:%M:%S",
         },
-    'filters':
-        {
-            'stdout_filter':
-                {
-                    '()': 'bpod_rig.log.stdout_filter',
-                }
+        "notime": {
+            "format": "[%(levelname)s] %(name)s: %(message)s",
         },
-    'handlers':
-        {
-        'stdout':
-            {
-            'class': 'logging.StreamHandler',
-            'level': 'INFO',
-            'formatter': 'notime',
-            'filters': ['stdout_filter'],
-            'stream': 'ext://sys.stdout'
-            },
-        'stderr':
-            {
-            'class': 'logging.StreamHandler',
-            'level': 'ERROR',
-            'formatter': 'time',
-            'stream': 'ext://sys.stderr'
-            },
-        'dynamic_file':
-            {
-                'class': 'bpod_rig.log.DynamicFileHandler',
-                'formatter': 'time',
-
-            }
-        },
-    'loggers':
-        {
-        '':
-            {
-            'handlers': ['stdout', 'stderr', 'dynamic_file'],
-            'level': 'DEBUG',
-            'propagate': True
-            }
+    },
+    "filters": {
+        "stdout_filter": {
+            "()": "bpod_rig.log.stdout_filter",
         }
-    }
+    },
+    "handlers": {
+        "stdout": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+            "formatter": "notime",
+            "filters": ["stdout_filter"],
+            "stream": "ext://sys.stdout",
+        },
+        "stderr": {
+            "class": "logging.StreamHandler",
+            "level": "ERROR",
+            "formatter": "time",
+            "stream": "ext://sys.stderr",
+        },
+        "dynamic_file": {
+            "class": "bpod_rig.log.DynamicFileHandler",
+            "formatter": "time",
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["stdout", "stderr", "dynamic_file"],
+            "level": "DEBUG",
+            "propagate": True,
+        }
+    },
+}
+
 
 def stdout_filter():
     def filter(lf: logging.LogRecord) -> bool:  # noqa: A001
         return logging.ERROR > lf.levelno >= logging.INFO
         # If 40 > lf.levelno >= 20
+
     return filter
 
 
@@ -102,7 +92,6 @@ class DynamicFileHandler(logging.FileHandler):
         self.new_filepath: Path | None = None
         super().__init__(self.temp_stream.name)
 
-
     def __del__(self) -> None:
         self.temp_stream.close()
         self.stream.close()
@@ -130,7 +119,7 @@ class DynamicFileHandler(logging.FileHandler):
         self._get_new_filepath()
         # Determine what our new logfile name should be
 
-        old_stream = self.setStream(open(self.new_filepath, 'a'))  # noqa: SIM115
+        old_stream = self.setStream(open(self.new_filepath, "a"))  # noqa: SIM115
         # Let's do this first so any remaining data is flushed from the stream
         # Set the stream to our new stream, which returns the old stream
 
@@ -229,4 +218,6 @@ class BpodLogger(logging.Logger):
         if self.file_handler:
             self.file_handler.swap_stream(logging_dir)
         else:
-            self.error("There is no DynamicFileHandler instance present for this logger!")
+            self.error(
+                "There is no DynamicFileHandler instance present for this logger!"
+            )

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -83,6 +83,7 @@ class DynamicFileHandler(logging.FileHandler):
         )
         self.log_dir: Path | None = None
         self.new_filepath: Path | None = None
+        self.logger: logging.Logger | None = None
         super().__init__(self.temp_stream.name)
 
     def __del__(self) -> None:
@@ -107,7 +108,6 @@ class DynamicFileHandler(logging.FileHandler):
         -------
             None
         """
-
         self.logger = logging.getLogger("temp_file_handler")
 
         if isinstance(logging_dir, str):
@@ -129,17 +129,23 @@ class DynamicFileHandler(logging.FileHandler):
 
         if self.new_filepath is not None:
             shutil.copyfile(self.temp_stream.name, self.new_filepath)
+            self.logger.debug(
+                "Copying and renaming temp logfile to %s", self.new_filepath
+            )
             # Copy and rename the temp logfile
             self.stream = open(self.new_filepath, "a")  # NOQA SIM115
+            self.logger.debug("Opening new file stream")
             # Open new stream and set to current stream
 
         self.temp_stream.close()  # Close the tempfile which should delete it
+        self.logger.debug("Closing temp file stream")
 
     def _set_new_filepath(self) -> None:
         current_dt = datetime.datetime.now().strftime(TIME_FORMAT)
         if self.log_dir is not None:
             self.new_filepath = self.log_dir / f"{LOGFILE_PREFIX}-{current_dt}.log"
-            self.logger.debug("New logfile path set to: %s", self.new_filepath)
+            if self.logger is not None:
+                self.logger.debug("New logfile path set to: %s", self.new_filepath)
 
 
 class BpodLogger(logging.Logger):

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -85,7 +85,7 @@ class DynamicFileHandler(logging.FileHandler):
 
     def __del__(self) -> None:
         self.temp_stream.close()
-        self.stream.close()
+        self.close()
 
     def swap_stream(self, logging_dir: Path | str):
         """Swaps the temporary stream for a file in the logging_dir directory.

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -1,3 +1,4 @@
+import atexit
 import datetime
 import logging
 import shutil
@@ -78,6 +79,7 @@ class DynamicFileHandler(logging.FileHandler):
     """
 
     def __init__(self):
+        atexit.register(self._cleanup)
         self.temp_stream = tempfile.NamedTemporaryFile(  # noqa: SIM115
             mode="w", delete=False, suffix=".log"
         )
@@ -86,7 +88,7 @@ class DynamicFileHandler(logging.FileHandler):
         self.logger: logging.Logger | None = None
         super().__init__(self.temp_stream.name)
 
-    def __del__(self) -> None:
+    def _cleanup(self) -> None:
         if self.temp_stream is not None:
             self.temp_stream.close()
         if self.stream is not None:

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -89,7 +89,7 @@ class DynamicFileHandler(logging.FileHandler):
         self.temp_stream = tempfile.NamedTemporaryFile()  # noqa: SIM115
         self.log_dir: Path | None = None
         self.current_logfile: Path | None = None
-        self.new_filepath: Path | None = None
+        self.new_filepath: Path
         super().__init__(self.temp_stream.name)
 
     def __del__(self) -> None:
@@ -125,10 +125,9 @@ class DynamicFileHandler(logging.FileHandler):
 
         shutil.copyfile(self.temp_stream.name, self.new_filepath)
         # Copy contents of temporary logfile into our new logfile
-
-        old_stream.close() # Close the old filestream
-        self.temp_stream.close() # Close the tempfile which should delete it
-
+        if old_stream is not None:
+            old_stream.close()  # Close the old filestream
+        self.temp_stream.close()  # Close the tempfile which should delete it
 
     def _get_new_filepath(self) -> None:
         """Function to help determine new logfile path.
@@ -141,24 +140,30 @@ class DynamicFileHandler(logging.FileHandler):
         -------
             None
         """
-        self._find_current_logfile()  # Is there a file with pattern "current-[date].log"
+        self._find_current_logfile()  # Is there a file with pattern current-[date].log?
 
         if self.current_logfile is not None:
             if self._current_file_from_past():
                 # Most recent logfile is old, rename it and create new "current"
                 self._rename_current_logfile()
-                self.new_filepath = self._new_logfile_path()
+                new_path = self._new_logfile_path()
+                if new_path is not None:
+                    self.new_filepath = new_path
             else:
                 # Most recent logfile is current
                 self.new_filepath = self.current_logfile
         else:
             # Catchall for a new log directory
-            self.new_filepath = self._new_logfile_path()
-
+            new_name = self._new_logfile_path()
+            if new_name is not None:
+                self.new_filepath = new_name
 
     def _find_current_logfile(self) -> None:
         """Checks self.log_dir for logfile matching the `current-[date].log` format."""
-        logfiles = self.log_dir.glob('*.log')
+        if self.log_dir is None:
+            return
+
+        logfiles = self.log_dir.glob("*.log")
         current_logfile = [file for file in logfiles if "current" in file.name]
         if len(current_logfile) == 0:
             # There is no current logfile
@@ -167,15 +172,16 @@ class DynamicFileHandler(logging.FileHandler):
             # logfile with 'current' in name found
             self.current_logfile = current_logfile[0]
 
-
-    def _current_file_from_past(self) -> bool:
+    def _current_file_from_past(self) -> bool | None:
         """Determines whether the date in a filename is from the past."""
-        date = self.current_logfile.stem.split("_")[1]
-        file_date = datetime.date.fromisoformat(date)
-        today_date = datetime.date.today()
+        if self.current_logfile:
+            date = self.current_logfile.stem.split("_")[1]
+            file_date = datetime.date.fromisoformat(date)
+            today_date = datetime.date.today()
 
-        return file_date < today_date
+            return file_date < today_date
 
+        return None
 
     def _rename_current_logfile(self) -> None:
         """Removes 'current' from logfile by renaming.
@@ -187,12 +193,16 @@ class DynamicFileHandler(logging.FileHandler):
         -------
             None
         """
+        if self.current_logfile is None:
+            return
+
         date = self.current_logfile.stem.split("_")[1]
         new_name = self.current_logfile.with_stem(date)
         self.current_logfile.rename(new_name)
 
-
-    def _new_logfile_path(self) -> Path:
+    def _new_logfile_path(self) -> Path | None:
+        if self.log_dir is None:
+            return None
         return self.log_dir.joinpath(f"current-{datetime.date.today()}.log")
 
 

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -4,12 +4,14 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from bpod_rig.defaults import TIME_FORMAT, LOGFILE_PREFIX
+
 LOGGING_CONFIG = {
     "version": 1,
     "disable_existing_loggers": True,
     "formatters": {
         "time": {
-            "format": "%(asctime)s - [%(levelname)s] %(name)s: %(message)s",
+            "format": "%(asctime)s.%(msecs)d - [%(levelname)s] %(name)s: %(message)s",
             "datefmt": "%H:%M:%S",
         },
         "notime": {
@@ -66,30 +68,17 @@ class DynamicFileHandler(logging.FileHandler):
     to. Once the logging directory is known, the output stream is swapped and the
     contents of the temp log copied over.
 
-    Currently, the naming convention for the currently used logfile will be:
-        current-[date].log
+    Logfiles are created with each launch of bpod-rig. Logfiles are named based on
+    the current ISO 8601-formatted date and time and a prefix.
 
-    The DynamicFileHandler will automatically handle logfile naming, renaming, and
-    selection using the criteria below.
+        e.g.: bpod-YYYY-MM-DDTHH:MM:SS.log
 
-    When swapping from the tempfile to a known logging directory, the DynamicFileHandler
-    will choose the correct logfile by making several checks within the new self.log_dir
-    directory:
-        1) If no logfiles exist, a new logfile named current-[date].log is used
-        2) If there are existing logfiles, but none contain the keyword `current`, a
-        new logfile named current-[date].log is created
-        3) If there is a logfile containing the keyword `current`, but the date is not
-        today, the keyword `current` is removed from the name, leaving just
-        [old_date].log Then, a new logfile named current-[date].log is created
-        4) If there is a logfile with the name current-[date].log and [date] is today,
-        that logfile is used
     """
 
     def __init__(self):
-        self.temp_stream = tempfile.NamedTemporaryFile()  # noqa: SIM115
+        self.temp_stream = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log")  # noqa: SIM115
         self.log_dir: Path | None = None
-        self.current_logfile: Path | None = None
-        self.new_filepath: Path
+        self.new_filepath: Path | None = None
         super().__init__(self.temp_stream.name)
 
     def __del__(self) -> None:
@@ -112,98 +101,35 @@ class DynamicFileHandler(logging.FileHandler):
         -------
             None
         """
+
         if isinstance(logging_dir, str):
             logging_dir = Path(logging_dir)
 
+        if not logging_dir.exists():
+            raise FileNotFoundError(f"Logging directory {logging_dir} does not exist!")
+
         self.log_dir = logging_dir
-        self._get_new_filepath()
+
+        if self.log_dir is None:
+            raise TypeError("Logging directory is not specified!")
+
+        self._set_new_filepath()
         # Determine what our new logfile name should be
 
-        old_stream = self.setStream(open(self.new_filepath, "a"))  # noqa: SIM115
-        # Let's do this first so any remaining data is flushed from the stream
-        # Set the stream to our new stream, which returns the old stream
-
+        self.close()
+        # Close current file stream and flush buffer
         shutil.copyfile(self.temp_stream.name, self.new_filepath)
-        # Copy contents of temporary logfile into our new logfile
-        if old_stream is not None:
-            old_stream.close()  # Close the old filestream
+        # Copy and rename the temp logfile
+
+        self.stream = open(self.new_filepath, "a")
+        # Open new stream and set to current stream
+
         self.temp_stream.close()  # Close the tempfile which should delete it
 
-    def _get_new_filepath(self) -> None:
-        """Function to help determine new logfile path.
 
-        This function uses the current logfile, determines if the date in the name is
-        old, triggers the file rename (if needed) and sets the self.new_filepath
-        parameter
-
-        Returns
-        -------
-            None
-        """
-        self._find_current_logfile()  # Is there a file with pattern current-[date].log?
-
-        if self.current_logfile is not None:
-            if self._current_file_from_past():
-                # Most recent logfile is old, rename it and create new "current"
-                self._rename_current_logfile()
-                new_path = self._new_logfile_path()
-                if new_path is not None:
-                    self.new_filepath = new_path
-            else:
-                # Most recent logfile is current
-                self.new_filepath = self.current_logfile
-        else:
-            # Catchall for a new log directory
-            new_name = self._new_logfile_path()
-            if new_name is not None:
-                self.new_filepath = new_name
-
-    def _find_current_logfile(self) -> None:
-        """Checks self.log_dir for logfile matching the `current-[date].log` format."""
-        if self.log_dir is None:
-            return
-
-        logfiles = self.log_dir.glob("*.log")
-        current_logfile = [file for file in logfiles if "current" in file.name]
-        if len(current_logfile) == 0:
-            # There is no current logfile
-            self.current_logfile = None
-        else:
-            # logfile with 'current' in name found
-            self.current_logfile = current_logfile[0]
-
-    def _current_file_from_past(self) -> bool | None:
-        """Determines whether the date in a filename is from the past."""
-        if self.current_logfile:
-            date = self.current_logfile.stem.split("_")[1]
-            file_date = datetime.date.fromisoformat(date)
-            today_date = datetime.date.today()
-
-            return file_date < today_date
-
-        return None
-
-    def _rename_current_logfile(self) -> None:
-        """Removes 'current' from logfile by renaming.
-
-        Takes the logfile with the name format "current-[date].log" and renames it
-        to "[date].log"
-
-        Returns
-        -------
-            None
-        """
-        if self.current_logfile is None:
-            return
-
-        date = self.current_logfile.stem.split("_")[1]
-        new_name = self.current_logfile.with_stem(date)
-        self.current_logfile.rename(new_name)
-
-    def _new_logfile_path(self) -> Path | None:
-        if self.log_dir is None:
-            return None
-        return self.log_dir.joinpath(f"current-{datetime.date.today()}.log")
+    def _set_new_filepath(self) -> None:
+        current_dt = datetime.datetime.now().strftime(TIME_FORMAT)
+        self.new_filepath = self.log_dir / f"{LOGFILE_PREFIX}-{current_dt}.log"
 
 
 class BpodLogger(logging.Logger):
@@ -215,8 +141,8 @@ class BpodLogger(logging.Logger):
 
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, name: str):
+        super().__init__(name)
 
         self.file_handler: DynamicFileHandler | None = None
 
@@ -228,6 +154,4 @@ class BpodLogger(logging.Logger):
         if self.file_handler:
             self.file_handler.swap_stream(logging_dir)
         else:
-            self.error(
-                "There is no DynamicFileHandler instance present for this logger!"
-            )
+            raise AttributeError("There is no DynamicFileHandler instance present for this logger!")


### PR DESCRIPTION
To create a strong base for our logging system, which will inevitably be complex, we introduce `bpod_rig.log`
The `log` module (which cannot be named logging as I found out since that overrides the standard lib, lol) implements the following:

- [x] A `LOGGING_CONFIG` dictionary to explicitly define logging behavior
    - [x] TODO: `bpod_core` needs to be checked to see if there is any logging behavior that should not be overwritten, as currently "disable_existing_loggers" is set to True
- [x] A `DynamicFileHandler` class to write logs to a temporary file until bpod_rig has initialized enough to have a path to the logging directory
   - [x] Creates a tempfile to write logs to
   - [x] Selects a new logfile based on criteria laid out in the docstring for the class
   - [x] Swaps the streams
   - [x] Copies any logs from the tempfile
   - [x] Closes any unused streams
- [x] A `BpodLogger` wrapper class to bring the `swap_stream` function of DynamicFileHandler to the topmost level
- [x] Set up a straight-forward logging scheme
    - [x] Info and Warnings are printed to file and stdout
    - [x] Errors and Critical are printed to file and stderr
    - [x] Debug messages are only printed to file
        - [x] TODO: Add a toggle to send these to stdout if desired