### PR TITLE
[Security] Configure UV to ignore young versions of dependencies

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,12 +10,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: astral-sh/setup-uv@v6
+      # astral-sh/setup-uv@8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
 
       # Use a cache to rapidly access known uv lockfiles.
       - name: Cache uv dependencies
-        uses: actions/cache@v3
+      # actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
             path: |
                 ~/.cache/uv
@@ -26,7 +29,8 @@ jobs:
 
       # Use Python version that is the primary support version.
       - name: Set up Python
-        uses: actions/setup-python@v4
+      # actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -43,8 +43,9 @@ jobs:
             uv run pyright .
             uv run python -m pytest --cov --cov-report=xml
 
-      # - name: Upload coverage to Coveralls
-      #   uses: coverallsapp/github-action@v2
-      #   with:
-      #     file: coverage.xml
-      #     parallel: false
+      - name: Upload coverage to Coveralls
+      # coverallsapp/github-action@v2.3.6
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b
+        with:
+          file: coverage.xml
+          parallel: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: astral-sh/setup-uv@v6
 
       # Use a cache to rapidly access known uv lockfiles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ bpod = "bpod_rig.__main__:main"
 
 [tool.uv]
 exclude-newer = "2 weeks"
-exclude-newer-package = {bpod-core=false}
+exclude-newer-package = { bpod-core = false }
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ find = { where = [""], include = ["*", "examples"] }
 [project.scripts]
 bpod = "bpod_rig.__main__:main"
 
+[tool.uv]
+exclude-newer = "2 weeks"
+exclude-newer-package = {bpod-core=false}
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,13 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2W"
+
+[options.exclude-newer-package]
+bpod-core = false
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
Due to recently supply chain attacks and compromises of several popular packages, make two small changes to uv configuration to improve security and reduce likelihood a compromised package is installed

- limit uv sync to packages >= 2 weeks old
- exempt bpod-core since it updates frequently and is constantly updated by dependabot