### PR TITLE
Use bpod-core ruff rules

### DIFF
--- a/bpod_rig/IO/reset.py
+++ b/bpod_rig/IO/reset.py
@@ -1,15 +1,15 @@
 # Module to delete all Bpod directories
 import logging
 import shutil
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from bpod_rig.cli import prompts
 
 logger = logging.getLogger(__name__)
 
 
-def reset_all(directories: Iterable[Path | str], force=False) -> bool:
+def reset_all(directories: Iterable[Path | str], *, force: bool = False) -> bool:
     """Function to hard reset all Bpod directories on this machine.
 
     USE AT OWN RISK!
@@ -49,7 +49,7 @@ def reset_all(directories: Iterable[Path | str], force=False) -> bool:
 
     for directory in directories:
         if not isinstance(directory, Path):
-            directory = Path(directory)
+            directory = Path(directory)  # noqa: PLW2901
         if directory.exists() and "bpod" in directory.name.lower():
             # A small sanity check so this does not just start deleting stuff
             logger.debug("Deleting: %s", directory)

--- a/bpod_rig/IO/startup.py
+++ b/bpod_rig/IO/startup.py
@@ -67,7 +67,7 @@ def create_default_directories(bpod_directory_path: Path) -> Path:
     return bpod_directory_path
 
 
-def copy_default_files(bpod_folder_path: Path, override: bool = False):
+def copy_default_files(bpod_folder_path: Path, *, override: bool = False) -> None:
     """Function to copy default files into their respective folders.
 
     Copies the default calibration and configuration files from the examples module

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -19,10 +19,10 @@ from bpod_rig.log import BpodLogger, get_log_config
 DEBUG = True
 
 # Set up logging here
-logging_config = get_log_config(DEBUG)
+logging_config = get_log_config(debug=DEBUG)
 dictConfig(logging_config)
 logging.setLoggerClass(BpodLogger)
-logger: BpodLogger = cast(BpodLogger, logging.getLogger(__name__))
+logger: BpodLogger = cast("BpodLogger", logging.getLogger(__name__))
 
 app = typer.Typer(no_args_is_help=True)
 app.add_typer(protocols_app, name="protocols")
@@ -30,7 +30,7 @@ app.add_typer(test_app, name="test")
 
 
 @app.command()
-def init():
+def init() -> int:
     """Initialize the Bpod Rig on this system."""
     ### Everything below is subject to change and is for testing purposes only
     logger.info("Starting bpod-rig!")
@@ -51,8 +51,8 @@ def init():
         # Create the system configuration directory
         try:
             SYSTEM_CONFIG_DIR.mkdir(exist_ok=True, parents=True)
-        except (IOError, OSError) as e:
-            logger.error(
+        except OSError as e:
+            logger.exception(
                 "Unable to create the system configuration directory: %s Exiting...",
                 SYSTEM_CONFIG_DIR,
                 exc_info=e,
@@ -67,7 +67,7 @@ def init():
         try:
             bpod_path = startup.get_bpod_dir_from_system()
         except ValidationError as e:
-            logger.error(
+            logger.exception(
                 "Configuration file at %s failed to validate! "
                 "Cannot read the Bpod Directory from existing configuration!",
                 SYSTEM_CONFIG_FILE,
@@ -139,7 +139,7 @@ def init():
         logger.debug("System paths at %s verified", bpod_path)
     else:
         logger.error("No valid Bpod directory! Shutting down.")
-        raise
+        raise RuntimeError("Bpod directory verification failed after initialization!")
 
     logger.swap_stream(system_paths.log_dir)
 
@@ -169,7 +169,7 @@ def run(
         str | None,
         typer.Option(..., help="Additional arguments for the protocol"),
     ] = None,
-):
+) -> None:
     """Run a protocol on the Bpod Rig.
 
     A protocol can be specified by its name if in protocol folder, or by a path to the
@@ -178,7 +178,7 @@ def run(
     raise NotImplementedError()
 
 
-def main():
+def main() -> None:
     app()
 
 

--- a/bpod_rig/calibration/liquid/models.py
+++ b/bpod_rig/calibration/liquid/models.py
@@ -144,7 +144,7 @@ class ValveData(BaseModel):
         self.coeffs = np.polyfit(self.amounts, self.durations, order).tolist()
 
     @field_serializer("lastdatemodified")
-    def serialize_datetime(self, dt: datetime.datetime, _info):
+    def serialize_datetime(self, dt: datetime.datetime) -> str:
         if isinstance(dt, str):  # if uncalibrated it is an empty string
             return dt
         return dt.isoformat(timespec="seconds")
@@ -168,7 +168,7 @@ class ValveManagerMetaData(BaseModel):
     )
 
     @field_serializer("modification_datetime")
-    def serialize_datetime(self, modification_datetime: datetime.datetime, _info):
+    def serialize_datetime(self, modification_datetime: datetime.datetime) -> str:
         return modification_datetime.isoformat(timespec="seconds")
 
 
@@ -211,7 +211,7 @@ class ValveDataManager(BaseModel):
         if valvename in self.valve_names:
             raise KeyError(f"Valve '{valvename}' already exists.")
         self.valves.append(ValveData(ValveName=valvename))
-        logger.debug(f"Created new valve: {valvename}")
+        logger.debug("Created new valve: %s", valvename)
 
     @property
     def n_valves(self) -> int:

--- a/bpod_rig/calibration/liquid/pending_calibration.py
+++ b/bpod_rig/calibration/liquid/pending_calibration.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
 import bpod_core.bpod
 from bpod_core.fsm import StateMachine
@@ -28,8 +28,8 @@ class PendingValve(ValveData):
         "(e.g., 'StateMachine', 'PortArray').",
     )
 
-    def __init__(self, **data):
-        super().__init__(**data)
+    def __init__(self, **data: object) -> None:
+        super().__init__(**cast("dict[str, Any]", data))  # TODO: this is ugly
         if self.name.startswith("PA"):
             self.valve_controller = "PortArray"
         elif self.name.startswith("Valve"):
@@ -98,7 +98,7 @@ class PendingMeasurementsManager:
     pulse_set_pause: float = 0.5
     """time (s) between each set of pulses"""
 
-    def __init__(self, valvemanager: ValveDataManager):
+    def __init__(self, valvemanager: ValveDataManager) -> None:
         self._valvemanager = valvemanager
         self.valves = [
             PendingValve(ValveName=valve.name) for valve in valvemanager.valves
@@ -217,7 +217,7 @@ def add_valve_states(
     duration: float,
     next_valve: PendingValve | float,
     interval_delay_duration: float,
-):
+) -> None:
     """Add the pending valve to a state machine.
 
     Parameters
@@ -296,6 +296,7 @@ def add_valve_states(
 def run_calibration(
     bpodsystem: bpod_core.bpod.Bpod,
     pending_manager: PendingMeasurementsManager,
+    *,
     verbose: bool = False,
 ) -> dict[str, float]:
     """Run a calibration sequence using Bpod state machine.

--- a/bpod_rig/calibration/liquid/populate_examples.py
+++ b/bpod_rig/calibration/liquid/populate_examples.py
@@ -51,7 +51,7 @@ def create_default_json() -> str:
     )
 
 
-def main():
+def main() -> None:
     """Create the example liquid calibration JSON in the example folder."""
     example_json = create_default_json()
     example_path = Path(example_folder.__path__[0]) / "LiquidCalibration.json"

--- a/bpod_rig/cli/prompts.py
+++ b/bpod_rig/cli/prompts.py
@@ -27,7 +27,7 @@ def yes_no_prompt_cli_runner(
 
 
 def verify_path(
-    unverified_path: str, prompt_for_file: bool = False, must_exist: bool = True
+    unverified_path: str, *, prompt_for_file: bool = False, must_exist: bool = True
 ) -> Path:
     """Verify that the user provides a valid path.
 
@@ -95,12 +95,15 @@ def verify_path(
 
 
 def prompt_for_path(
-    prompt: str, is_file: bool = False, must_exist: bool = True
+    prompt: str, *, is_file: bool = False, must_exist: bool = True
 ) -> Path | None:
     logger.debug("Asking user to select a path: %s", prompt)
     try:
         return typer.prompt(
-            prompt, value_proc=lambda path: verify_path(path, is_file, must_exist)
+            prompt,
+            value_proc=lambda path: verify_path(
+                path, prompt_for_file=is_file, must_exist=must_exist
+            ),
         )
     except typer.Abort:
         logger.debug("User aborted before answering!")

--- a/bpod_rig/cli/protocols.py
+++ b/bpod_rig/cli/protocols.py
@@ -11,7 +11,7 @@ app = typer.Typer(
 
 
 @app.command(name="list")
-def list_protocols():
+def list_protocols() -> None:
     """List all available protocols on the system."""
     _ = get_settings()
     raise NotImplementedError("Protocol searcher required.")
@@ -20,8 +20,9 @@ def list_protocols():
 @app.command()
 def open(  # noqa: A001
     protocol: Annotated[str | None, typer.Option()] = None,
+    *,
     open_file: Annotated[bool, typer.Option()] = False,
-):
+) -> None:
     """Open a protoocl folder (or file)."""
     raise NotImplementedError("Protocol searcher required.")
 

--- a/bpod_rig/cli/test.py
+++ b/bpod_rig/cli/test.py
@@ -15,7 +15,7 @@ app = typer.Typer(
 
 
 @app.command()
-def software():
+def software() -> None:
     """Run software tests to verify installation."""
     tests_path = prepare_tests()
     exit_code = run_test(tests_path, hardware=False)
@@ -23,7 +23,7 @@ def software():
 
 
 @app.command()
-def hardware():
+def hardware() -> None:
     """Run hardware tests to verify hardware functionality."""
     tests_path = prepare_tests()
     exit_code = run_test(tests_path, hardware=True)
@@ -33,7 +33,7 @@ def hardware():
 def prepare_tests() -> Path:
     """Find the tests directory in the installed package."""
     try:
-        import pytest  # noqa: F401
+        import pytest  # noqa: F401, PLC0415
     except ImportError:
         typer.secho(
             "Error: pytest not installed. Install test dependencies with:",
@@ -63,7 +63,7 @@ def prepare_tests() -> Path:
     return tests_path
 
 
-def report_test_result(exit_code: int):
+def report_test_result(exit_code: int) -> None:
     """Print end-result message to console."""
     if exit_code == 0:
         typer.secho("\n✓ All tests passed!", fg=typer.colors.GREEN, bold=True)
@@ -71,7 +71,7 @@ def report_test_result(exit_code: int):
         typer.secho("\n✗ Some tests failed.", fg=typer.colors.RED, bold=True)
 
 
-def run_test(test_path: Path, hardware: bool = False) -> int:
+def run_test(test_path: Path, *, hardware: bool = False) -> int:
     """Execute pytest on test path."""
     run_command = f"pytest {test_path} -v"
     if hardware:

--- a/bpod_rig/config/base.py
+++ b/bpod_rig/config/base.py
@@ -3,7 +3,7 @@
 import datetime
 import logging
 import pathlib
-from typing import Annotated, Any, Optional
+from typing import Annotated
 
 from pydantic import (
     BaseModel,
@@ -31,7 +31,7 @@ class SettingsMetadata(BaseModel):
     ] = datetime.date.today()
 
     modified_datetime: Annotated[
-        Optional[datetime.datetime | PastDate],  # Optional, but can be either type
+        datetime.datetime | PastDate | None,  # Optional, but can be either type
         Field(
             None,
             title="Settings Save Date and Time",
@@ -40,7 +40,7 @@ class SettingsMetadata(BaseModel):
     ] = None
 
     username: Annotated[
-        Optional[str],
+        str | None,
         Field(
             min_length=1,
             max_length=128,
@@ -79,7 +79,7 @@ class ModelWithMetadata(BaseModel):
     # noinspection PyNestedDecorators
     @model_validator(mode="before")
     @classmethod
-    def forward_username(cls, data: Any) -> Any:
+    def forward_username(cls, data: object) -> object:
         """Bring username into metadata.
 
         For simplicity, allow the user to pass username to the SystemSettings
@@ -93,21 +93,26 @@ class ModelWithMetadata(BaseModel):
 
         Parameters
         ----------
-        data : Any
+        data : object
             Unparsed kwargs dict passed to the SystemSettings constructor
 
         Returns
         -------
-        Any
+        object
             Kwargs dict modified to be passed to the SystemSettings constructor
         """
+        if not isinstance(data, dict):
+            return data
+
         if "metadata" not in data and "username" in data:
             # if the user passed in a dictionary for metadata, we will just forward it
             # otherwise, forward the "username" field to SettingsMetadata and return it
-            data["metadata"] = SettingsMetadata(username=data["username"])
+            username = data["username"]
+            if isinstance(username, str):
+                data["metadata"] = SettingsMetadata(username=username)
         return data
 
-    def update_modification_time(self):
+    def update_modification_time(self) -> None:
         """
         Update metadata modified_datetime field.
 
@@ -123,7 +128,7 @@ class ModelWithMetadata(BaseModel):
         logger.debug("Setting modification time for [%s] to %s", self, time)
         self.metadata.modified_datetime = time
 
-    def save_model(self, save_directory: pathlib.Path, filename: str):
+    def save_model(self, save_directory: pathlib.Path, filename: str) -> pathlib.Path:
         """Dump model to JSON and save it to disk.
 
         Parameters

--- a/bpod_rig/config/system_settings.py
+++ b/bpod_rig/config/system_settings.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 from pydantic import UUID4, Field, PastDate
 from pydantic_core import from_json
@@ -192,7 +192,7 @@ class SystemSettings(ModelWithMetadata):
     ]
 
     last_update_check: Annotated[
-        Optional[PastDate],
+        PastDate | None,
         Field(
             title="Last update check date and time",
             description="Last date and time that system checked for any updates"
@@ -201,7 +201,7 @@ class SystemSettings(ModelWithMetadata):
     ] = None
 
     phone_home_id: Annotated[
-        Optional[UUID4],
+        UUID4 | None,
         Field(
             title="System's Unique Phone-Home ID",
             description="UUID4 ID of the current system"
@@ -235,7 +235,7 @@ class SystemSettings(ModelWithMetadata):
     ]
 
     bpod_dirs: Annotated[
-        Optional[list[BpodPaths]],
+        list[BpodPaths] | None,
         Field(
             title="All Bpod Paths",
             description="List containing BpodPaths objects that contain"
@@ -251,7 +251,7 @@ class SystemSettings(ModelWithMetadata):
         current_version: str = "0.0.0",
         phone_home_opt_in: bool = False,
         debug: bool = False,
-        bpod_dirs: Optional[list[BpodPaths]] = None,
+        bpod_dirs: list[BpodPaths] | None = None,
         username: str | None = None,
         metadata: "SettingsMetadata | None" = None,
     ) -> "SystemSettings":
@@ -297,7 +297,7 @@ class SystemSettings(ModelWithMetadata):
             metadata=metadata or SettingsMetadata(username=username),
         )
 
-    def update_modification_time(self):
+    def update_modification_time(self) -> None:
         """Update time the SystemSettings object was modified.
 
         Override update_modification_time to also update the modified_datetime metadata

--- a/bpod_rig/examples/copy.py
+++ b/bpod_rig/examples/copy.py
@@ -8,8 +8,8 @@ logger = logging.getLogger(__name__)
 
 
 def copy_examples(
-    source_key: str, destination: pathlib.Path, override_contents: bool = False
-):
+    source_key: str, destination: pathlib.Path, *, override_contents: bool = False
+) -> None:
     source_modules = examples.__all__
 
     if source_key not in source_modules:
@@ -34,6 +34,6 @@ def copy_examples(
             try:
                 logger.debug("Attempting to copy %s to %s...", file, destination)
                 shutil.copy2(file, destination)
-            except Exception as e:  # NOQA PERF203
-                logger.error("Error copying %s!", file)
-                raise e
+            except Exception:  # noqa: PERF203
+                logger.exception("Error copying %s!", file)
+                raise

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import shutil
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 from bpod_rig.defaults import LOGFILE_PREFIX, TIME_FORMAT
@@ -55,7 +56,7 @@ LOGGING_CONFIG = {
 }
 
 
-def get_log_config(debug: bool = False) -> dict:
+def get_log_config(*, debug: bool = False) -> dict:
     """Factory function to get logging configuration.
 
     If debug is True, DEBUG messages are passed through to stdout
@@ -77,7 +78,7 @@ def get_log_config(debug: bool = False) -> dict:
     return LOGGING_CONFIG
 
 
-def stdout_filter():
+def stdout_filter() -> Callable[[logging.LogRecord], bool]:
     def filter(lf: logging.LogRecord) -> bool:  # noqa: A001
         return logging.ERROR > lf.levelno >= logging.INFO
         # If 40 > lf.levelno >= 20
@@ -100,7 +101,7 @@ class DynamicFileHandler(logging.FileHandler):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         atexit.register(self._cleanup)
         self.temp_stream = tempfile.NamedTemporaryFile(  # noqa: SIM115
             mode="w", delete=False, suffix=".log"
@@ -119,7 +120,7 @@ class DynamicFileHandler(logging.FileHandler):
         if self.stream is not None:
             self.close()
 
-    def swap_stream(self, logging_dir: Path | str):
+    def swap_stream(self, logging_dir: Path | str) -> None:
         """Swaps the temporary stream for a file in the logging_dir directory.
 
         This function has multiple steps:
@@ -183,7 +184,7 @@ class BpodLogger(logging.Logger):
 
     """
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
 
         self.file_handler: DynamicFileHandler | None = None
@@ -192,7 +193,7 @@ class BpodLogger(logging.Logger):
             if isinstance(handler, DynamicFileHandler):
                 self.file_handler = handler
 
-    def swap_stream(self, logging_dir: Path | str):
+    def swap_stream(self, logging_dir: Path | str) -> None:
         if self.file_handler:
             self.file_handler.swap_stream(logging_dir)
         else:

--- a/bpod_rig/protocols/manager.py
+++ b/bpod_rig/protocols/manager.py
@@ -8,7 +8,7 @@ class ProtocolManager:
 
     protocols: set[Path]
 
-    def __init__(self, protocol_dir: Path):
+    def __init__(self, protocol_dir: Path) -> None:
         if not protocol_dir.exists():
             raise FileNotFoundError(
                 f"Protocol directory {protocol_dir} does not exist."
@@ -16,7 +16,7 @@ class ProtocolManager:
         self.protocol_dir = protocol_dir
         self.load_protocols()
 
-    def load_protocols(self):
+    def load_protocols(self) -> None:
         """Load protocols from the protocol directory."""
         # Expect protocols to be in a subfolder with the same name as the protocol file
         self.protocols = set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,29 +90,40 @@ target-version = "py310"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = [
-    "D",
-    "E",
-    "F",
-    "YTT",
-    "S",
-    "B",
-    "A",
-    "COM",
-    "C4",
-    "FA",
-    "I",
-    "ICN",
-    "INP",
-    "PIE",
-    "PYI",
-    "RET",
-    "SIM",
-    "ARG",
-    "NPY",
-    "PD",
-    "N",
-    "PERF",
-    "UP007", # use pipes for type union instead of Union
+    "A",    # flake8-builtins
+    "ANN",  # flake8-annotations
+    "ARG",  # flake8-unused-arguments
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "D",    # pydocstyle
+    "E",    # pycodestyle Error
+    "F",    # Pyflakes
+    "FA",   # flake8-future-annotations
+    "FBT",  # flake8-boolean-trap
+    "FURB", # refurb
+    "G",    # flake8-logging-format
+    "I",    # isort
+    "ICN",  # flake8-import-conventions
+    "ISC",  # flake8-implicit-str-concat
+    "LOG",  # flake8-logging
+    "N",    # pep8-naming
+    "NPY",  # NumPy-specific rules
+    "PERF", # Perflint
+    "PIE",  # flake8-pie
+    "PL",   # pylint
+    "PTH",  # flake8-use-pathlib
+    "Q",    # flake8-quotes
+    "RET",  # flake8-return
+    "RUF",  # Ruff-specific rules
+    "S",    # flake8-bandit
+    "SIM",  # flake8-simplify
+    "SLF",  # flake8-self
+    "T20",  # flake8-print
+    "TID",  # flake8-tidy-imports
+    "TC",   # flake8-type-checking
+    "TRY",  # tryceratops
+    "UP",   # pyupgrade
+    "W",    # pycodestyle Warning
 ]
 
 ignore = [
@@ -127,10 +138,12 @@ ignore = [
     "D401",    # First line of docstring should be in imperative mood
     "PERF401", # Prefer list comprehension over for loop
     "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments
     "PLR0915", # Too many statements
     "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
     "RET504",  # Unnecessary assignment to variable (e.g., `return x` instead of `x = ...; return x`)
     "S101",    # Use of assert
+    "TRY003",  # Avoid specifying long messages outside the exception class
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -138,6 +151,19 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+"!tests/**.py" = [
+    "PT", # flake8-pytest-style
+]
+"tests/**.py" = [
+    "ARG001", # Unused function argument
+    "ARG002", # Unused method argument
+    "PERF",   # Perflint
+    "S101",   # Use of assert detected
+    "S104",   # Possible binding to all interfaces
+    "SLF001", # private-member-access
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/tests/bpod_rig/IO/test_json_handler.py
+++ b/tests/bpod_rig/IO/test_json_handler.py
@@ -1,5 +1,6 @@
 import shutil
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -10,7 +11,7 @@ JSON_STRING = '{"first_key":{"second_key": "1234"}}'
 
 
 @pytest.fixture
-def temp_dir():
+def temp_dir() -> Generator[Path, None, None]:
     """
     A pytest fixture that creates a temporary directory for a test
     and handles cleanup automatically after the test has finished.
@@ -23,7 +24,7 @@ def temp_dir():
 
 
 class TestJSONHandler:
-    def test_save(self, temp_dir):
+    def test_save(self, temp_dir: Path) -> None:
         """Tests that a JSON string can be successfully written to a file."""
         full_path = temp_dir.joinpath("temp.json")
 
@@ -32,28 +33,28 @@ class TestJSONHandler:
         assert returned_path == full_path
         assert full_path.exists()
 
-        with open(full_path, "r") as fs:
+        with full_path.open() as fs:
             file_content = fs.read()
 
         assert file_content == JSON_STRING
 
-    def test_save_bad_path(self, temp_dir):
+    def test_save_bad_path(self, temp_dir: Path) -> None:
         """Tests that write_json errors if the target directory does not exist."""
         bad_dir = temp_dir.joinpath("bad_dir")
 
         with pytest.raises(FileNotFoundError):
             _ = json_handler.write_json(JSON_STRING, bad_dir, "temp")
 
-    def test_load(self, temp_dir):
+    def test_load(self, temp_dir: Path) -> None:
         """Tests that a JSON file can be successfully read."""
         test_file = temp_dir.joinpath("config.json")
-        with open(test_file, "w") as tf:
+        with test_file.open("w") as tf:
             tf.write(JSON_STRING)
 
         returned_data = json_handler.read_json(test_file)
         assert returned_data == JSON_STRING
 
-    def test_load_bad_path(self, temp_dir):
+    def test_load_bad_path(self, temp_dir: Path) -> None:
         """Tests that read_json returns None if the file does not exist."""
         bad_file = temp_dir.joinpath("dne.json")
 

--- a/tests/bpod_rig/IO/test_startup.py
+++ b/tests/bpod_rig/IO/test_startup.py
@@ -1,4 +1,5 @@
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -8,7 +9,7 @@ from bpod_rig.IO import startup
 
 class TestCreateDefaultDirectories:
     @pytest.fixture(autouse=True)
-    def setup_and_teardown(self):
+    def setup_and_teardown(self) -> Generator[None, None, None]:
         """Setup and teardown."""
         self.temp_dir = tempfile.TemporaryDirectory()
         self.temp_path = Path(self.temp_dir.name)
@@ -18,6 +19,6 @@ class TestCreateDefaultDirectories:
 
         self.temp_dir.cleanup()
 
-    def test_folder_creation(self):
+    def test_folder_creation(self) -> None:
         startup.create_default_directories(self.bpod_path)
         assert self.bpod_path.exists()

--- a/tests/bpod_rig/calibration/liquid/test_models.py
+++ b/tests/bpod_rig/calibration/liquid/test_models.py
@@ -8,56 +8,56 @@ from bpod_rig.calibration.liquid.models import ValveData, ValveDataManager
 
 class TestValveDataClass:
     @pytest.fixture(autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.valve = ValveData(ValveName="Test Valve")
 
-    def test_init_alias(self):
+    def test_init_alias(self) -> None:
         # Test that alias works correctly
         # type checker may complain about this because of pydantic aliasing
         assert ValveData(name="attrname").name == "attrname"  # pyright: ignore[reportCallIssue]
         assert ValveData(ValveName="aliasname").name == "aliasname"
 
-    def test_add_measurement(self):
+    def test_add_measurement(self) -> None:
         self.valve.add_measurement(10, 1.0)
         assert len(self.valve.amounts) == 1
         assert len(self.valve.durations) == 1
 
-    def test_get_valve_time(self):
+    def test_get_valve_time(self) -> None:
         self.valve.add_measurement(10, 1.0)
         self.valve.add_measurement(20, 2.0)
         duration = self.valve.get_valve_time(1.0)
         assert duration == pytest.approx(10)
 
-    def test_remove_measurement_by_index(self):
+    def test_remove_measurement_by_index(self) -> None:
         self.valve.add_measurement(10, 1.0)
         self.valve.remove_measurement(0)
         assert len(self.valve.amounts) == 0
 
-    def test_remove_measurement_by_duration(self):
+    def test_remove_measurement_by_duration(self) -> None:
         self.valve.add_measurement(10, 1.0)
         self.valve.remove_measurement(10, method="duration")
         assert len(self.valve.amounts) == 0
 
-    def test_remove_measurement_invalid_index(self):
+    def test_remove_measurement_invalid_index(self) -> None:
         self.valve.add_measurement(10, 1.0)
         self.valve.add_measurement(20, 2.0)
         self.valve.remove_measurement(0)
         with pytest.raises(IndexError):
             self.valve.remove_measurement(5)
 
-    def test_remove_measurement_invalid_duration(self):
+    def test_remove_measurement_invalid_duration(self) -> None:
         self.valve.add_measurement(10, 1.0)
         self.valve.add_measurement(20, 2.0)
         with pytest.raises(ValueError):
             self.valve.remove_measurement(15, method="duration")
 
-    def test_remove_measurement_duplicate_duration(self):
+    def test_remove_measurement_duplicate_duration(self) -> None:
         self.valve.add_measurement(10, 1.0)
         self.valve.add_measurement(10, 2.0)
         with pytest.raises(ValueError):
             self.valve.remove_measurement(10, method="duration")
 
-    def test_no_coeffs_with_insufficient_data(self):
+    def test_no_coeffs_with_insufficient_data(self) -> None:
         self.valve.add_measurement(10, 1.0)
         assert len(self.valve.coeffs) == 0
         with pytest.raises(ValueError):
@@ -68,22 +68,22 @@ class TestValveDataClass:
 
 class TestValveDataManagerClass:
     @pytest.fixture(autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.manager = ValveDataManager()
         self.manager.create_valve("Test Valve")
         dummy = utils.create_empty_valve_data_manager()
         populate_examples.add_dummy_measurements(dummy)
         self.dummy = dummy
 
-    def test_create_valve(self):
+    def test_create_valve(self) -> None:
         assert self.manager.n_valves == 1
         assert "Test Valve" in self.manager.valve_names
 
-    def test_get_valve(self):
+    def test_get_valve(self) -> None:
         valve = self.manager.get_valve("Test Valve")
         assert isinstance(valve, ValveData)
 
-    def test_measurements(self):
+    def test_measurements(self) -> None:
         """Test that the default values are behaving as expected."""
         liquid_amount = 15
 
@@ -102,7 +102,7 @@ class TestGen2CalibrationFile:
     """Test loading a calibration file from the Bpod_Gen2 (MATLAB) repo."""
 
     @pytest.fixture(scope="class")
-    def jsontext(self):
+    def jsontext(self) -> str:
         return (
             urllib.request.urlopen(
                 "https://raw.githubusercontent.com/sanworks/Bpod_Gen2/refs/heads/develop/Examples/Example%20Calibration%20Files/LiquidCalibration.json"
@@ -111,13 +111,13 @@ class TestGen2CalibrationFile:
             .decode()
         )
 
-    def test_load_calibration_file(self, jsontext):
+    def test_load_calibration_file(self, jsontext: str) -> None:
         loaded_valves = ValveDataManager.model_validate_json(jsontext)
         assert isinstance(loaded_valves, ValveDataManager)
         assert loaded_valves.n_valves >= 1
         assert "Valve1" in loaded_valves.valve_names
 
-    def test_valve_modtime(self, jsontext):
+    def test_valve_modtime(self, jsontext: str) -> None:
         valvemanager = ValveDataManager.model_validate_json(jsontext)
         assert not utils.check_valvemanager_user_updated(valvemanager)
         newvalve = ValveDataManager.model_validate_json(valvemanager.to_json())
@@ -126,13 +126,13 @@ class TestGen2CalibrationFile:
 
 class TestValveDataManagerJSON:
     @pytest.fixture(autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.manager = utils.create_empty_valve_data_manager()
         populate_examples.add_dummy_measurements(self.manager)
         self.json_str = self.manager.to_json()
         self.loaded_manager = ValveDataManager.model_validate_json(self.json_str)
 
-    def test_json_round_trip(self):
+    def test_json_round_trip(self) -> None:
         assert self.manager.n_valves == self.loaded_manager.n_valves
         assert self.manager.valve_names == self.loaded_manager.valve_names
         for valve_name in self.manager.valve_names:

--- a/tests/bpod_rig/calibration/liquid/test_pending_calibration.py
+++ b/tests/bpod_rig/calibration/liquid/test_pending_calibration.py
@@ -6,20 +6,20 @@ from bpod_rig.calibration.liquid import pending_calibration, populate_examples, 
 
 class TestPendingValve:
     @pytest.fixture(autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.pending_valve = pending_calibration.PendingValve(ValveName="Valve3")
 
-    def test_valve_controller_assignment(self):
+    def test_valve_controller_assignment(self) -> None:
         valve1 = pending_calibration.PendingValve(ValveName="PA1")
         valve2 = pending_calibration.PendingValve(ValveName="Valve1")
         assert valve1.valve_controller == "PortArray"
         assert valve2.valve_controller == "StateMachine"
 
-    def test_unrecognied_controller_assignment(self):
+    def test_unrecognied_controller_assignment(self) -> None:
         with pytest.raises(ValueError):
             pending_calibration.PendingValve(ValveName="HeartValve")
 
-    def test_ispending(self):
+    def test_ispending(self) -> None:
         valve = pending_calibration.PendingValve(ValveName="Valve1")
         assert not valve.is_pending
         valve = pending_calibration.PendingValve(ValveName="Valve1")
@@ -29,40 +29,40 @@ class TestPendingValve:
 
 class TestPendingMeasurementsManager:
     @pytest.fixture(autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.valvemanager = utils.create_empty_valve_data_manager()
         populate_examples.add_dummy_measurements(self.valvemanager)
         self.manager = pending_calibration.PendingMeasurementsManager(self.valvemanager)
 
-    def test_get_pending_initial(self):
+    def test_get_pending_initial(self) -> None:
         assert self.manager.get_pending("Valve1") == []
         assert self.manager.get_pending("Valve2") == []
 
-    def test_get_pending_invalid_valve(self):
+    def test_get_pending_invalid_valve(self) -> None:
         with pytest.raises(KeyError):
             self.manager.get_pending("InvalidValve")
 
-    def test_add_pending(self):
+    def test_add_pending(self) -> None:
         self.manager.add_pending("Valve1", 10.0)  # valve with values
         assert 10.0 in self.manager.get_pending("Valve1")
         self.manager.add_pending("Valve2", 10.0)  # valve without values
         assert 10.0 in self.manager.get_pending("Valve2")
 
-    def test_add_pending_duplicate(self):
+    def test_add_pending_duplicate(self) -> None:
         self.manager.add_pending("Valve1", 10.0)
         with pytest.raises(ValueError):
             self.manager.add_pending("Valve1", 10.0)
 
-    def test_remove_pending(self):
+    def test_remove_pending(self) -> None:
         self.manager.add_pending("Valve1", 10.0)
         self.manager.remove_pending("Valve1", 10.0)
         assert 10.0 not in self.manager.get_pending("Valve1")
 
-    def test_remove_pending_nonexistent(self):
+    def test_remove_pending_nonexistent(self) -> None:
         with pytest.raises(ValueError):
             self.manager.remove_pending("Valve1", 10.0)
 
-    def test_complete_measurement(self):
+    def test_complete_measurement(self) -> None:
         self.manager.add_pending("Valve2", 10.0)
         self.manager.complete_measurement("Valve2", 10.0, 1.5)
         valve = self.valvemanager.get_valve("Valve2")
@@ -70,13 +70,13 @@ class TestPendingMeasurementsManager:
         assert 1.5 in valve.amounts
         assert 10.0 not in self.manager.get_pending("Valve2")
 
-    def test_build_testset(self):
+    def test_build_testset(self) -> None:
         self.manager.add_pending("Valve1", 10)
         self.manager.add_pending("Valve1", 5)
         self.manager.add_pending("Valve2", 20)
         assert self.manager.build_test_set() == {"Valve1": 10, "Valve2": 20}
 
-    def test_build_statemachine(self):
+    def test_build_statemachine(self) -> None:
         self.manager.add_pending("Valve1", 10)
         self.manager.add_pending("Valve2", 15)
         statemachine, test_set = self.manager.build_statemachine()

--- a/tests/bpod_rig/calibration/liquid/test_utils.py
+++ b/tests/bpod_rig/calibration/liquid/test_utils.py
@@ -4,11 +4,12 @@ import pytest
 
 from bpod_rig.calibration.liquid import utils
 from bpod_rig.calibration.liquid.models import ValveData, ValveDataManager
+from bpod_rig.calibration.liquid.populate_examples import create_default_json
 
 
 class TestSuggestDuration:
     @pytest.fixture(autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.valve = ValveData(ValveName="Test Valve")
         self.range_low = 2
         self.range_high = 10
@@ -16,14 +17,14 @@ class TestSuggestDuration:
             self.valve, self.range_low, self.range_high
         )
 
-    def test_no_measures(self):
+    def test_no_measures(self) -> None:
         assert self.suggest_duration() == 48
 
-    def test_one_measure(self):
+    def test_one_measure(self) -> None:
         self.valve.add_measurement(57, 7.5)
         assert self.suggest_duration() == 36
 
-    def test_two_measures(self):
+    def test_two_measures(self) -> None:
         self.valve.add_measurement(22, 2)
         self.valve.add_measurement(66, 9.5)
         assert self.suggest_duration() == pytest.approx(44.0, abs=0.001)
@@ -31,24 +32,23 @@ class TestSuggestDuration:
 
 class TestCheckValveManagerUserUpdate:
     @pytest.fixture(autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.manager = ValveDataManager()
 
-    def test_earlier(self):
+    def test_earlier(self) -> None:
         self.manager.metadata.modification_datetime = datetime.datetime(1999, 1, 1)
         assert not utils.check_valvemanager_user_updated(self.manager)
 
-    def test_later(self):
+    def test_later(self) -> None:
         self.manager.create_valve("Valve1")
         self.manager.get_valve("Valve1").add_measurement(15, 20)
         assert utils.check_valvemanager_user_updated(self.manager)
 
-    def test_equal(self):
+    def test_equal(self) -> None:
         self.manager.metadata.modification_datetime = datetime.datetime(2000, 1, 1)
         assert not utils.check_valvemanager_user_updated(self.manager)
 
-    def test_dummy(self):
-        from bpod_rig.calibration.liquid.populate_examples import create_default_json
+    def test_dummy(self) -> None:
 
         manager = ValveDataManager.model_validate_json(create_default_json())
         assert not utils.check_valvemanager_user_updated(manager)
@@ -56,16 +56,16 @@ class TestCheckValveManagerUserUpdate:
 
 class TestCheckCOM:
     @pytest.fixture(autouse=True)
-    def setup_method(self):
+    def setup_method(self) -> None:
         self.manager = ValveDataManager()
         self.manager.metadata.COM = "COM3"
 
-    def test_matching(self):
+    def test_matching(self) -> None:
         assert utils.check_com(self.manager, "COM3") == "yes"
 
-    def test_no_match(self):
+    def test_no_match(self) -> None:
         assert utils.check_com(self.manager, "COM4") == "no"
 
-    def test_unknown(self):
+    def test_unknown(self) -> None:
         self.manager.metadata.COM = ""
         assert utils.check_com(self.manager, "COM3") == "unknown"

--- a/tests/bpod_rig/cli/test_prompts.py
+++ b/tests/bpod_rig/cli/test_prompts.py
@@ -1,5 +1,6 @@
 import logging
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,7 +12,7 @@ from bpod_rig.cli.prompts import app as prompt_app
 
 class TestCliIO:
     @pytest.fixture(autouse=True)
-    def setup_and_teardown(self):
+    def setup_and_teardown(self) -> Generator[None, None, None]:
         """Setup and teardown."""
         self.temp_dir = tempfile.TemporaryDirectory()
         self.temp_path = Path(self.temp_dir.name)
@@ -27,7 +28,7 @@ class TestCliIO:
         self.temp_file.unlink()
         self.temp_dir.cleanup()
 
-    def test_yes_no_prompt(self, caplog):
+    def test_yes_no_prompt(self, caplog: pytest.LogCaptureFixture) -> None:
         y1 = self.runner.invoke(
             prompt_app,
             ["yes-no-prompt-cli-runner", "--prompt", "Testing..."],
@@ -86,7 +87,7 @@ class TestCliIO:
             # assert early.return_value is None
             assert "aborted" in caplog.text
 
-    def test_prompt_for_path(self, caplog):
+    def test_prompt_for_path(self, caplog: pytest.LogCaptureFixture) -> None:
 
         exists = self.runner.invoke(
             prompt_app,

--- a/tests/bpod_rig/config/test_models.py
+++ b/tests/bpod_rig/config/test_models.py
@@ -1,5 +1,6 @@
 import datetime
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
 from pydantic import ValidationError
@@ -17,7 +18,7 @@ class TestMetadataModel:
         assert bm.modified_datetime is None
         assert bm.username == "BpodUser"
 
-    def test_good_manual_vals(self):
+    def test_good_manual_vals(self) -> None:
         """Tests creating a SettingsMetadata model with valid manual values."""
         past_creation_date = datetime.date(2025, 1, 1)
         past_save_datetime = datetime.datetime(2025, 2, 1)
@@ -33,7 +34,7 @@ class TestMetadataModel:
         assert bm.modified_datetime == past_save_datetime
         assert bm.username == new_user
 
-    def test_validator_failure(self):
+    def test_validator_failure(self) -> None:
         """Tests that pydantic validators raise ValidationErrors for bad data."""
         with pytest.raises(ValidationError):
             future_creation_date = datetime.date(3000, 1, 1)
@@ -54,7 +55,7 @@ class TestMetadataModel:
 
 class TestSystemPathsModel:
     @pytest.fixture
-    def paths(self, tmp_path):
+    def paths(self, tmp_path: Path) -> dict[str, Path]:
         """Fixture to provide a common set of path objects for tests."""
         working_dir = tmp_path
         bpod_dir = working_dir.joinpath("Bpod")
@@ -65,14 +66,14 @@ class TestSystemPathsModel:
             "data_dir": bpod_dir.joinpath("Data"),
         }
 
-    def test_default_factory(self, paths):
+    def test_default_factory(self, paths: dict[str, Path]) -> None:
         """Tests that the default directory paths are constructed correctly."""
         sp = BpodDir.create(base_dir=paths["bpod_dir"])
         assert sp.data_dir == paths["data_dir"]
         assert sp.base_config_dir == paths["config_dir"]
         assert sp.protocol_dir == paths["protocol_dir"]
 
-    def test_pass_username(self, paths):
+    def test_pass_username(self, paths: dict[str, Path]) -> None:
         """Tests that a username can be passed through to the metadata."""
         paths["bpod_dir"].mkdir(exist_ok=True)
         paths["data_dir"].mkdir(exist_ok=True)
@@ -91,7 +92,7 @@ class TestSystemPathsModel:
         )
         assert sp2.metadata.username != "beepbop"
 
-    def test_not_paths(self):
+    def test_not_paths(self) -> None:
         """Tests that non-path inputs for directories raise validation errors."""
         with pytest.raises(TypeError):
             BpodDir.create(base_dir=1234321)  # type: ignore
@@ -100,9 +101,17 @@ class TestSystemPathsModel:
         assert isinstance(sp.base_dir, Path)
 
 
+class BpodPathsDict(TypedDict):
+    base_dir: Path
+    bpod_id: str
+    bpod_dir: Path
+    config_dir: Path
+    calibration_dir: Path
+
+
 class TestBpodPathsModel:
     @pytest.fixture
-    def paths(self, tmp_path: Path):
+    def paths(self, tmp_path: Path) -> BpodPathsDict:
         """Fixture to provide a common set of Bpod-specific path objects."""
         working_dir = tmp_path
         base_dir = working_dir.joinpath("Bpods")
@@ -116,7 +125,7 @@ class TestBpodPathsModel:
             "calibration_dir": bpod_dir.joinpath("Calibration"),
         }
 
-    def test_id_validation(self, paths):
+    def test_id_validation(self, paths: BpodPathsDict) -> None:
         """Tests validation for the bpod_id field."""
         # No ID, fails validation
         with pytest.raises(TypeError):
@@ -133,7 +142,7 @@ class TestBpodPathsModel:
         bp = BpodPaths.create(bpod_id=paths["bpod_id"], parent_dir=paths["base_dir"])
         assert bp.bpod_id == paths["bpod_id"]
 
-    def test_default_factory(self, paths):
+    def test_default_factory(self, paths: BpodPathsDict) -> None:
         """Tests that the Bpod-specific paths are constructed correctly."""
         bp = BpodPaths.create(bpod_id=paths["bpod_id"], parent_dir=paths["base_dir"])
         assert bp.unique_bpod_dir == paths["bpod_dir"]
@@ -144,22 +153,21 @@ class TestBpodPathsModel:
 
 class TestSystemSettingsModel:
     @pytest.fixture
-    def paths(self, tmp_path):
+    def paths(self, tmp_path: Path) -> dict[str, BpodDir]:
         """Fixture to provide a common set of path objects for tests."""
         working_dir = tmp_path
         bpod_dir = working_dir.joinpath("Bpod")
         system_paths = BpodDir.create(base_dir=bpod_dir)
         return {"system_paths": system_paths}
 
-    def test_default(self, paths):
+    def test_default(self, paths: dict[str, BpodDir]) -> None:
         """Tests that the default system settings are constructed correctly."""
-        paths = paths["system_paths"]
-        settings = SystemSettings.create(paths=paths)
+        settings = SystemSettings.create(paths=paths["system_paths"])
 
         assert settings.current_version == "0.0.0"
         assert settings.last_update_check is None
         assert settings.phone_home_id is None
         assert not settings.phone_home_opt_in
         assert not settings.debug
-        assert settings.paths == paths
+        assert settings.paths == paths["system_paths"]
         assert settings.bpod_dirs is None

--- a/tests/bpod_rig/config/test_save_load.py
+++ b/tests/bpod_rig/config/test_save_load.py
@@ -1,6 +1,8 @@
 import shutil
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
 from pydantic_core import ValidationError
@@ -14,8 +16,15 @@ from bpod_rig.config.system_settings import (
 JSON_STRING = '{"first_key":{"second_key": "1234"}}'
 
 
+class TempConfigDict(TypedDict):
+    system_settings: SystemSettings
+    config_dir: Path
+    full_file_path: Path
+    bpod_dir: Path
+
+
 @pytest.fixture
-def temp_config():
+def temp_config() -> Generator[TempConfigDict, None, None]:
     """
     A pytest fixture that sets up a temporary directory structure and
     configuration objects for testing. It handles cleanup automatically
@@ -29,88 +38,95 @@ def temp_config():
     full_file_path = ss.paths.base_config_dir.joinpath("config.json")
 
     # Yield the created objects to the test function
-    yield ss, config_dir, full_file_path, bpod_dir
+    yield TempConfigDict(
+        system_settings=ss,
+        config_dir=config_dir,
+        full_file_path=full_file_path,
+        bpod_dir=bpod_dir,
+    )
 
     # --- Teardown ---
     shutil.rmtree(bpod_dir, ignore_errors=True)
 
 
 class TestSave:
-    def test_save(self, temp_config):
+    def test_save(self, temp_config: TempConfigDict) -> None:
         """Tests that the configuration is saved to the default path correctly."""
-        ss, config_dir, full_file_path, _ = temp_config
-        config_dir.mkdir(exist_ok=True)
-        save_path = ss.save_system_configuration()
+        temp_config["config_dir"].mkdir(exist_ok=True)
+        save_path = temp_config["system_settings"].save_system_configuration()
+        full_file_path = temp_config["full_file_path"]
 
         assert save_path == full_file_path
         assert full_file_path.exists()
 
-        with open(full_file_path, "r") as fs:
-            assert fs.read() == ss.model_dump_json(indent=2)
+        with full_file_path.open() as fs:
+            assert fs.read() == temp_config["system_settings"].model_dump_json(indent=2)
 
-    def test_save_path_override(self, temp_config):
+    def test_save_path_override(self, temp_config: TempConfigDict) -> None:
         """Tests that the configuration can be saved to a non-default directory."""
-        ss, config_dir, _, bpod_dir = temp_config
-        config_dir.mkdir(exist_ok=True)
-        save_path = ss.save_system_configuration(save_dir_override=ss.paths.base_dir)
+        temp_config["config_dir"].mkdir(exist_ok=True)
+        save_path = temp_config["system_settings"].save_system_configuration(
+            save_dir_override=temp_config["system_settings"].paths.base_dir
+        )
 
-        alt_file_path = bpod_dir.joinpath("config.json")
+        alt_file_path = temp_config["bpod_dir"].joinpath("config.json")
 
         assert save_path == alt_file_path
         assert alt_file_path.exists()
 
-        with open(alt_file_path, "r") as fs:
-            assert fs.read() == ss.model_dump_json(indent=2)
+        with alt_file_path.open() as fs:
+            assert fs.read() == temp_config["system_settings"].model_dump_json(indent=2)
 
-    def test_invalid_default_path(self, temp_config):
+    def test_invalid_default_path(self, temp_config: TempConfigDict) -> None:
         """Tests that saving errors if the default directory does not exist."""
-        ss, _, _, _ = temp_config
         # Note: We don't create the config_dir here
         with pytest.raises(FileNotFoundError):
-            _ = ss.save_system_configuration()
+            _ = temp_config["system_settings"].save_system_configuration()
 
-    def test_invalid_override_path(self, temp_config):
+    def test_invalid_override_path(self, temp_config: TempConfigDict) -> None:
         """Tests that saving errors if the override directory does not exist."""
-        ss, _, _, bpod_dir = temp_config
-        invalid_dir = bpod_dir.joinpath("InvalidDir")
+        invalid_dir = temp_config["bpod_dir"].joinpath("InvalidDir")
         with pytest.raises(FileNotFoundError):
-            _ = ss.save_system_configuration(save_dir_override=invalid_dir)
+            _ = temp_config["system_settings"].save_system_configuration(
+                save_dir_override=invalid_dir
+            )
 
 
 class TestLoad:
-    def test_load(self, temp_config):
+    def test_load(self, temp_config: TempConfigDict) -> None:
         """Tests that a valid configuration file can be loaded
         into a SystemSettings object.
         """
-        ss, config_dir, full_file_path, _ = temp_config
-        config_dir.mkdir(exist_ok=True)
+        temp_config["config_dir"].mkdir(exist_ok=True)
 
-        with open(full_file_path, "w") as fs:
-            fs.write(ss.model_dump_json(indent=2))
+        with temp_config["full_file_path"].open("w") as fs:
+            fs.write(temp_config["system_settings"].model_dump_json(indent=2))
 
-        loaded_system_settings = load_system_configuration(full_file_path)
-        assert loaded_system_settings == ss
+        loaded_system_settings = load_system_configuration(
+            temp_config["full_file_path"]
+        )
+        assert loaded_system_settings == temp_config["system_settings"]
 
-    def test_bad_json(self, temp_config):
+    def test_bad_json(self, temp_config: TempConfigDict) -> None:
         """Tests that loading errors when the file contains invalid JSON."""
-        ss, config_dir, full_file_path, _ = temp_config
-        config_dir.mkdir(exist_ok=True)
+        temp_config["config_dir"].mkdir(exist_ok=True)
 
-        with open(full_file_path, "w") as fs:
-            fs.write(ss.model_dump_json(indent=2)[:-1])  # Write incomplete JSON
+        with temp_config["full_file_path"].open("w") as fs:
+            fs.write(
+                temp_config["system_settings"].model_dump_json(indent=2)[:-1]
+            )  # Write incomplete JSON
 
         with pytest.raises(ValueError):
-            _ = load_system_configuration(full_file_path)
+            _ = load_system_configuration(temp_config["full_file_path"])
 
-    def test_invalid_schema(self, temp_config):
+    def test_invalid_schema(self, temp_config: TempConfigDict) -> None:
         """
         Tests that loading returns None when the JSON does not match the pydantic
         model schema.
         """
-        _, config_dir, full_file_path, _ = temp_config
-        config_dir.mkdir(exist_ok=True)
+        temp_config["config_dir"].mkdir(exist_ok=True)
 
-        with open(full_file_path, "w") as fs:
+        with temp_config["full_file_path"].open("w") as fs:
             fs.write(JSON_STRING)
         with pytest.raises(ValidationError):
-            _ = load_system_configuration(full_file_path)
+            _ = load_system_configuration(temp_config["full_file_path"])

--- a/tests/bpod_rig/examples/test_copy.py
+++ b/tests/bpod_rig/examples/test_copy.py
@@ -1,6 +1,7 @@
 import pathlib
 import shutil
 import tempfile
+from collections.abc import Generator
 
 import pytest
 
@@ -8,7 +9,7 @@ from bpod_rig.examples import calibration, copy, settings
 
 
 @pytest.fixture()
-def temp_dirs():
+def temp_dirs() -> Generator[pathlib.Path, None, None]:
     temp_dest_dir = pathlib.Path(tempfile.mkdtemp())
 
     yield temp_dest_dir
@@ -17,7 +18,7 @@ def temp_dirs():
 
 
 class TestCopyExamples:
-    def test_copy(self, temp_dirs):
+    def test_copy(self, temp_dirs: pathlib.Path) -> None:
         calibration_dir = temp_dirs.joinpath("calibration")
         settings_dir = temp_dirs.joinpath("settings")
         calibration_dir.mkdir()
@@ -40,11 +41,11 @@ class TestCopyExamples:
         for file in expected_settings_files:
             assert file in settings_contents
 
-    def test_invalid_key(self):
+    def test_invalid_key(self) -> None:
         with pytest.raises(ValueError):
             copy.copy_examples("invalid_key", pathlib.Path())
 
-    def test_invalid_path(self, temp_dirs):
+    def test_invalid_path(self, temp_dirs: pathlib.Path) -> None:
         with pytest.raises(FileNotFoundError):
             copy.copy_examples("calibration", temp_dirs.joinpath("~~(__^·>"))
             # The directory ~~(__^·> (mouse) does not exist!

--- a/tests/bpod_rig/protocols/test_manager.py
+++ b/tests/bpod_rig/protocols/test_manager.py
@@ -75,7 +75,7 @@ def protocol_folder(
 class TestFindProtocolFile:
     """Test suite for finding protocol files."""
 
-    def test_basic_find(self, protocol_folder):
+    def test_basic_find(self, protocol_folder: Path) -> None:
         """Test finding a unique protocol at the root level."""
         expected_path = protocol_folder / "Protocol_unique1" / "Protocol_unique1.py"
 
@@ -84,7 +84,7 @@ class TestFindProtocolFile:
 
         assert result_path == expected_path
 
-    def test_no_match_fail(self, protocol_folder):
+    def test_no_match_fail(self, protocol_folder: Path) -> None:
         """Test that an error is raised when no match is found."""
         manager = ProtocolManager(protocol_folder)
         with pytest.raises(
@@ -92,7 +92,7 @@ class TestFindProtocolFile:
         ):
             manager.find_protocol_file("Protocol_noMatch")
 
-    def test_invalid_match_fail(self, protocol_folder):
+    def test_invalid_match_fail(self, protocol_folder: Path) -> None:
         """Test that an error is raised when a file matches but is invalid."""
         manager = ProtocolManager(protocol_folder)
         with pytest.raises(
@@ -100,7 +100,7 @@ class TestFindProtocolFile:
         ):
             manager.find_protocol_file("Protocol_invalid1")
 
-    def test_subfolder_find(self, protocol_folder):
+    def test_subfolder_find(self, protocol_folder: Path) -> None:
         """Test finding a protocol in a subfolder."""
         expected_path = (
             protocol_folder / "subfolderB" / "Protocol_unique3" / "Protocol_unique3.py"
@@ -111,7 +111,7 @@ class TestFindProtocolFile:
 
         assert result_path == expected_path
 
-    def test_ambiguous_match_unix(self, protocol_folder):
+    def test_ambiguous_match_unix(self, protocol_folder: Path) -> None:
         """Test with a UNIX-style path to resolve ambiguity."""
         expected_path = (
             protocol_folder
@@ -125,7 +125,7 @@ class TestFindProtocolFile:
 
         assert result_path == expected_path
 
-    def test_ambiguous_match_win(self, protocol_folder):
+    def test_ambiguous_match_win(self, protocol_folder: Path) -> None:
         """Test with a Windows-style path to resolve ambiguity."""
         expected_path = (
             protocol_folder
@@ -139,7 +139,7 @@ class TestFindProtocolFile:
 
         assert result_path == expected_path
 
-    def test_ambiguous_match_subfolder(self, protocol_folder):
+    def test_ambiguous_match_subfolder(self, protocol_folder: Path) -> None:
         """Test with a subfolder path that has multiple matches."""
         expected_path = (
             protocol_folder
@@ -153,37 +153,37 @@ class TestFindProtocolFile:
 
         assert result_path == expected_path
 
-    def test_ambiguous_match_fail(self, protocol_folder):
+    def test_ambiguous_match_fail(self, protocol_folder: Path) -> None:
         """Test that an error is raised when there are multiple matches."""
         manager = ProtocolManager(protocol_folder)
         with pytest.raises(
-            ValueError, match="Multiple protocols found.*Protocol_matching1"
+            ValueError, match=r"Multiple protocols found.*Protocol_matching1"
         ):
             manager.find_protocol_file("Protocol_matching1")
 
-    def test_subfolder_ambiguous_match_fail(self, protocol_folder):
+    def test_subfolder_ambiguous_match_fail(self, protocol_folder: Path) -> None:
         """Test that an error is raised for multiple matches across subfolders."""
         manager = ProtocolManager(protocol_folder)
         with pytest.raises(
-            ValueError, match="Multiple protocols found.*Protocol_matching2"
+            ValueError, match=r"Multiple protocols found.*Protocol_matching2"
         ):
             manager.find_protocol_file("Protocol_matching2")
 
 
 class TestProtocolManager:
-    def test_initialization(self, protocol_folder):
+    def test_initialization(self, protocol_folder: Path) -> None:
         """Test that the ProtocolManager initializes without error."""
         manager = ProtocolManager(protocol_folder)
         assert manager.protocol_dir == protocol_folder
 
-    def test_nonexistent_directory(self):
+    def test_nonexistent_directory(self) -> None:
         """Test that initializing with a nonexistent directory raises an error."""
         non_existent_path = Path("/path/does/not/exist")
         with pytest.raises(
-            FileNotFoundError, match="Protocol directory .* does not exist."
+            FileNotFoundError, match=r"Protocol directory .* does not exist."
         ):
             ProtocolManager(non_existent_path)
 
-    def test_load_protocols(self, protocol_folder):
+    def test_load_protocols(self, protocol_folder: Path) -> None:
         manager = ProtocolManager(protocol_folder)
         assert len(manager.protocols) == 7


### PR DESCRIPTION
For consistency purposes, use the same basic Ruff ruleset as `bpod-core`. This PR doesn't change any functionality.