### PR TITLE
BpodManager

### DIFF
--- a/bpod_rig/IO/json_handler.py
+++ b/bpod_rig/IO/json_handler.py
@@ -1,7 +1,8 @@
-import logging
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from bpod_rig import log
+
+logger = log.get_logger(__name__)
 
 
 def write_json(json_content: str, save_path: Path, file_name: str) -> Path:

--- a/bpod_rig/IO/reset.py
+++ b/bpod_rig/IO/reset.py
@@ -5,8 +5,9 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from bpod_rig.cli import prompts
+from bpod_rig import log
 
-logger = logging.getLogger(__name__)
+logger = log.get_logger(__name__)
 
 
 def reset_all(directories: Iterable[Path | str], *, force: bool = False) -> bool:

--- a/bpod_rig/IO/reset.py
+++ b/bpod_rig/IO/reset.py
@@ -1,11 +1,10 @@
 # Module to delete all Bpod directories
-import logging
 import shutil
 from collections.abc import Iterable
 from pathlib import Path
 
-from bpod_rig.cli import prompts
 from bpod_rig import log
+from bpod_rig.cli import prompts
 
 logger = log.get_logger(__name__)
 

--- a/bpod_rig/IO/startup.py
+++ b/bpod_rig/IO/startup.py
@@ -1,8 +1,8 @@
 """Module to create the default Bpod user directory and associated subdirs."""
 
-import logging
 from pathlib import Path
 
+from bpod_rig import log
 from bpod_rig.config import system_settings
 from bpod_rig.defaults import (
     DEFAULT_SUBDIRS,
@@ -11,7 +11,7 @@ from bpod_rig.defaults import (
 )
 from bpod_rig.examples.copy import copy_examples
 
-logger = logging.getLogger(__name__)
+logger = log.get_logger(__name__)
 
 
 def create_default_directories(bpod_directory_path: Path) -> Path:

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -2,7 +2,7 @@
 
 import logging
 from logging.config import dictConfig
-from typing import Annotated, cast
+from typing import Annotated
 
 import typer
 from pydantic import ValidationError

--- a/bpod_rig/__main__.py
+++ b/bpod_rig/__main__.py
@@ -14,7 +14,7 @@ from bpod_rig.config import utils
 from bpod_rig.config.system_settings import BpodDir
 from bpod_rig.defaults import DEFAULT_BPOD_PATH, SYSTEM_CONFIG_DIR, SYSTEM_CONFIG_FILE
 from bpod_rig.IO import startup
-from bpod_rig.log import BpodLogger, get_log_config
+from bpod_rig.log import BpodLogger, get_log_config, get_logger
 
 DEBUG = True
 
@@ -22,7 +22,7 @@ DEBUG = True
 logging_config = get_log_config(debug=DEBUG)
 dictConfig(logging_config)
 logging.setLoggerClass(BpodLogger)
-logger: BpodLogger = cast("BpodLogger", logging.getLogger(__name__))
+logger: BpodLogger = get_logger(__name__)
 
 app = typer.Typer(no_args_is_help=True)
 app.add_typer(protocols_app, name="protocols")

--- a/bpod_rig/calibration/liquid/models.py
+++ b/bpod_rig/calibration/liquid/models.py
@@ -1,12 +1,13 @@
 """Data models for liquid calibration."""
 
 import datetime
-import logging
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
-logger = logging.getLogger(__name__)
+from bpod_rig import log
+
+logger = log.get_logger(__name__)
 
 
 class ValveData(BaseModel):

--- a/bpod_rig/calibration/liquid/pending_calibration.py
+++ b/bpod_rig/calibration/liquid/pending_calibration.py
@@ -1,13 +1,13 @@
-import logging
 from typing import Any, cast
 
 import bpod_core.bpod
 from bpod_core.fsm import StateMachine
 from pydantic import Field
 
+from bpod_rig import log
 from bpod_rig.calibration.liquid.models import ValveData, ValveDataManager
 
-logger = logging.getLogger(__name__)
+logger = log.get_logger(__name__)
 
 
 class PendingValve(ValveData):
@@ -319,10 +319,6 @@ def run_calibration(
     # Build the state machine
     fsm, test_set = pending_manager.build_statemachine()
     if verbose:
-        root_logger = logging.getLogger()
-        if not root_logger.hasHandlers():
-            logging.basicConfig(level=logging.INFO)
-
         logger.info("Running liquid calibration:")
         logger.info("\t%s pulses.", pending_manager.n_pulses)
         logger.info("\t%s between each pulse.", pending_manager.pulse_interval)

--- a/bpod_rig/calibration/liquid/utils.py
+++ b/bpod_rig/calibration/liquid/utils.py
@@ -1,13 +1,13 @@
 """Liquid calibration data management and calibration routines."""
 
 import datetime
-import logging
 
 import numpy as np
 
+from bpod_rig import log
 from bpod_rig.calibration.liquid.models import ValveData, ValveDataManager
 
-logger = logging.getLogger(__name__)
+logger = log.get_logger(__name__)
 
 
 def create_empty_valve_data_manager(

--- a/bpod_rig/cli/prompts.py
+++ b/bpod_rig/cli/prompts.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 from typing import Annotated
 

--- a/bpod_rig/cli/prompts.py
+++ b/bpod_rig/cli/prompts.py
@@ -5,7 +5,9 @@ from typing import Annotated
 # import click
 import typer
 
-logger = logging.getLogger(__name__)
+from bpod_rig import log
+
+logger = log.get_logger(__name__)
 
 app = typer.Typer()
 

--- a/bpod_rig/config/base.py
+++ b/bpod_rig/config/base.py
@@ -14,9 +14,10 @@ from pydantic import (
     model_validator,
 )
 
+from bpod_rig import log
 from bpod_rig.IO import json_handler
 
-logger = logging.getLogger(__name__)
+logger = log.get_logger(__name__)
 
 
 class SettingsMetadata(BaseModel):

--- a/bpod_rig/config/base.py
+++ b/bpod_rig/config/base.py
@@ -1,7 +1,6 @@
 """Base classes for configuration classes."""
 
 import datetime
-import logging
 import pathlib
 from typing import Annotated
 

--- a/bpod_rig/config/system_settings.py
+++ b/bpod_rig/config/system_settings.py
@@ -1,12 +1,12 @@
 """Module implementing the Pydantic models for any system settings."""
 
-import logging
 from pathlib import Path
 from typing import Annotated
 
 from pydantic import UUID4, Field, PastDate
 from pydantic_core import from_json
 
+from bpod_rig import log
 from bpod_rig.config.base import ModelWithMetadata, SettingsMetadata
 from bpod_rig.config.bpod_settings import BpodPaths
 from bpod_rig.defaults import (
@@ -18,7 +18,7 @@ from bpod_rig.defaults import (
 )
 from bpod_rig.IO import json_handler
 
-logger = logging.getLogger(__name__)
+logger = log.get_logger(__name__)
 
 
 class BpodDir(ModelWithMetadata):

--- a/bpod_rig/config/utils.py
+++ b/bpod_rig/config/utils.py
@@ -1,9 +1,9 @@
-import logging
 from pathlib import Path
 
+from bpod_rig import log
 from bpod_rig.config.system_settings import BpodDir, SystemSettings
 
-logger = logging.getLogger(__name__)
+logger = log.get_logger(__name__)
 
 
 def init_system_configuration(bpod_dir: Path) -> SystemSettings:

--- a/bpod_rig/examples/copy.py
+++ b/bpod_rig/examples/copy.py
@@ -2,9 +2,9 @@ import logging
 import pathlib
 import shutil
 
-from bpod_rig import examples
+from bpod_rig import examples, log
 
-logger = logging.getLogger(__name__)
+logger = log.get_logger(__name__)
 
 
 def copy_examples(

--- a/bpod_rig/examples/copy.py
+++ b/bpod_rig/examples/copy.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 import shutil
 

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -9,8 +9,6 @@ from typing import Any, cast
 
 from bpod_rig.defaults import LOGFILE_PREFIX, TIME_FORMAT
 
-# logger = logging.getLogger(__name__)
-
 LOGGING_CONFIG: dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": True,
@@ -140,7 +138,7 @@ class DynamicFileHandler(logging.FileHandler):
         -------
             None
         """
-        self.logger = logging.getLogger("temp_file_handler")
+        self.logger = get_logger("temp_file_handler")
 
         if isinstance(logging_dir, str):
             logging_dir = Path(logging_dir)

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -5,12 +5,13 @@ import shutil
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any, cast
 
 from bpod_rig.defaults import LOGFILE_PREFIX, TIME_FORMAT
 
 # logger = logging.getLogger(__name__)
 
-LOGGING_CONFIG = {
+LOGGING_CONFIG: dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": True,
     "formatters": {
@@ -200,3 +201,9 @@ class BpodLogger(logging.Logger):
             raise AttributeError(
                 "There is no DynamicFileHandler instance present for this logger!"
             )
+
+
+def get_logger(name: str) -> BpodLogger:
+    """Get a logger with a specific name and case its type to BpodLogger."""
+    return cast("BpodLogger", logging.getLogger(name))
+

--- a/bpod_rig/log.py
+++ b/bpod_rig/log.py
@@ -204,4 +204,3 @@ class BpodLogger(logging.Logger):
 def get_logger(name: str) -> BpodLogger:
     """Get a logger with a specific name and case its type to BpodLogger."""
     return cast("BpodLogger", logging.getLogger(name))
-

--- a/bpod_rig/managers/__init__.py
+++ b/bpod_rig/managers/__init__.py
@@ -1,0 +1,3 @@
+from bpod_rig.managers.bpod_manager import BpodManager
+
+__all__ = ["BpodManager"]

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -1,0 +1,111 @@
+import logging
+import multiprocessing as mp
+from multiprocessing.connection import Connection
+from pathlib import Path
+from typing import cast, Optional, TypeAlias
+
+from bpod_core.bpod import Bpod, BpodInfo, discover_bpod, discover_remote_bpod
+
+from bpod_rig.calibration.liquid.models import ValveDataManager
+from bpod_rig.calibration.liquid.pending_calibration import PendingMeasurementsManager
+from bpod_rig.log import BpodLogger
+from bpod_rig.protocols.runner import load_protocol_function
+
+SerialNumber: TypeAlias = str
+
+class BpodManager:
+    def __init__(self, *args, **kwargs) -> None:
+        self.logger: BpodLogger = cast(BpodLogger, logging.getLogger(__name__))
+        self._all_local_bpods: dict[SerialNumber, BpodInfo] | None = None
+        # self.remote_bpods: dict[SerialNumber, BpodInfo] | None = None
+
+        self.last_selected_bpod: BpodInfo | None = None
+
+
+    def load(self):
+        self._get_local_bpods()
+
+
+    def select_bpod(self, serial: SerialNumber = None, index: int = 0) -> BpodInfo:
+        """Returns a BpodInfo instance
+
+        Function will return the BpodInfo instance with the given serial number or
+        index. serial will always take precedence over index. If no parameter is
+        provided, the first BpodInfo instance will be returned.
+
+        Parameters
+        ----------
+        serial : SerialNumber (optional)
+            SerialNumber of the Bpod to select
+        index : int (optional)
+            index of the Bpod to select
+
+        Returns
+        -------
+
+        BpodInfo instance
+
+        """
+
+        if self._all_local_bpods is None:
+            raise ValueError("No local Bpods found!")
+
+        serials: list[SerialNumber] = list(self._all_local_bpods.keys())
+
+        if serial is not None:
+            if serial in self._all_local_bpods.keys():
+                self.last_selected_bpod = self._all_local_bpods[serial]
+            else:
+                raise KeyError(f"Bpod {serial} not found!")
+
+        if index > len(serials) or index < 0:
+            raise IndexError(f"Index {index} out of range!")
+
+        self.last_selected_bpod = self._all_local_bpods[serials[index]]
+        return self.last_selected_bpod
+
+
+    def _format_all_bpods_info(self):
+        if self._all_local_bpods is None:
+            return "No local Bpods found to list!"
+
+        info = [
+            f"[{i}]: Local Bpod\n"
+            f"Name: {info.name} | Serial Number: {sn}\n"
+            f"Port: {info.port} | Location: {info.location}\n\n"
+            for i, sn, info in enumerate(self._all_local_bpods.items())
+        ]
+
+        return f"The following Bpods are available:\n{info}"
+
+
+    def _get_local_bpods(self):
+        local_bpods = discover_bpod()
+        # remote_bpods = discover_remote_bpod()
+
+        self._all_local_bpods = {
+            info.serial_number: info
+            for info in local_bpods
+        }
+        # self.remote_bpods = {
+        #     info.serial_number: info
+        #     for info in remote_bpods
+        # }
+
+        if self._all_local_bpods is None:
+            self.logger.warning("No local Bpods found!")
+
+        return self._all_local_bpods
+
+
+    @property
+    def bpod(self):
+        if self.last_selected_bpod is not None:
+            return self.last_selected_bpod
+        else:
+            return None
+
+    def __str__(self):
+        return self._format_all_bpods_info()
+
+

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -1,32 +1,30 @@
 import logging
-import multiprocessing as mp
-from multiprocessing.connection import Connection
-from pathlib import Path
-from typing import Optional, TypeAlias, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
 
-from bpod_core.bpod import Bpod, BpodInfo, discover_bpod, discover_remote_bpod
+from bpod_core.bpod import BpodInfo, discover_bpod
 
-from bpod_rig.calibration.liquid.models import ValveDataManager
-from bpod_rig.calibration.liquid.pending_calibration import PendingMeasurementsManager
-from bpod_rig.log import BpodLogger
-from bpod_rig.protocols.runner import load_protocol_function
+if TYPE_CHECKING:
+    from bpod_rig.log import BpodLogger
+
 
 SerialNumber: TypeAlias = str
 
+
 class BpodManager:
-    def __init__(self, *args, **kwargs) -> None:
-        self.logger: BpodLogger = cast(BpodLogger, logging.getLogger(__name__))
+    def __init__(self) -> None:
+        self.logger: BpodLogger = cast("BpodLogger", logging.getLogger(__name__))
         self._all_local_bpods: dict[SerialNumber, BpodInfo] | None = None
         # self.remote_bpods: dict[SerialNumber, BpodInfo] | None = None
 
         self.current_bpod: BpodInfo | None = None
+        self.refresh()
 
-
-    def load(self):
+    def refresh(self) -> None:
         self._get_local_bpods()
 
-
-    def select_bpod(self, serial: SerialNumber | None = None, index: int = 0) -> BpodInfo:
+    def select_bpod(
+        self, serial: SerialNumber | None = None, index: int = 0
+    ) -> BpodInfo:
         """Returns a BpodInfo instance.
 
         Function will return the BpodInfo instance with the given serial number or
@@ -48,23 +46,21 @@ class BpodManager:
         if self._all_local_bpods is None:
             raise ValueError("No local Bpods found!")
 
-
         serials: list[SerialNumber] = list(self._all_local_bpods.keys())
 
         if serial is not None:
             if serial in serials:
-                self.current_bpod = self._all_local_bpods[serial] # type: ignore
+                self.current_bpod = self._all_local_bpods[serial]  # type: ignore
             else:
                 raise KeyError(f"Bpod {serial} not found!")
         else:
             if index > len(serials) or index < 0:
                 raise IndexError(f"Index {index} out of range!")
-            self.current_bpod = self._all_local_bpods[serials[index]] # type: ignore
+            self.current_bpod = self._all_local_bpods[serials[index]]  # type: ignore
 
         return self.current_bpod
 
-
-    def _format_all_bpods_info(self):
+    def _format_all_bpods_info(self) -> str:
         if self._all_local_bpods is None:
             return "No local Bpods found to list!"
 
@@ -77,8 +73,7 @@ class BpodManager:
 
         return f"The following Bpods are available:\n {info}"
 
-
-    def _get_local_bpods(self):
+    def _get_local_bpods(self) -> dict[SerialNumber, BpodInfo] | None:
         local_bpods = list(discover_bpod())
         # remote_bpods = discover_remote_bpod()
 
@@ -87,10 +82,7 @@ class BpodManager:
             self.logger.warning("No local Bpods found!")
             return None
 
-        self._all_local_bpods = {
-            info.serial_number: info
-            for info in local_bpods
-        }
+        self._all_local_bpods = {info.serial_number: info for info in local_bpods}
         # self.remote_bpods = {
         #     info.serial_number: info
         #     for info in remote_bpods
@@ -98,13 +90,9 @@ class BpodManager:
 
         return self._all_local_bpods
 
-
     @property
-    def bpod(self):
+    def bpod(self) -> BpodInfo | None:
         return self.current_bpod
 
-
-    def __str__(self):
+    def __str__(self) -> str:
         return self._format_all_bpods_info()
-
-

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -22,6 +22,7 @@ class BpodManager:
         self.refresh()
 
     def refresh(self) -> None:
+        self.logger.info("Looking for Bpods...")
         self._get_local_bpods()
 
     def select_bpod(
@@ -51,30 +52,35 @@ class BpodManager:
 
         Raises
         ------
+            IndexError
+                Raised if an invalid index is provided
             ValueError
                 Raised if no Bpod is found, an identifier is not provided when required,
                 or the identifier does not exist
 
-
         """
         if self._all_local_bpods is None:
+            self.logger.debug("No local Bpods found!")
             raise ValueError("No local Bpods found!")
 
         serials: list[SerialNumber] = list(self._all_local_bpods.keys())
 
         if serial is not None:
             if serial in serials:
+                self.logger.info("Bpod with serial %s found!", serial)
                 self.current_bpod = self._all_local_bpods[serial]  # type: ignore
             else:
                 raise ValueError(f"Bpod {serial} not found!")
         elif index is not None:
             if 0 > index > len(serials):
                 raise IndexError(f"Index {index} out of range!")
+            self.logger.info("Bpod with index %d found!", index)
             self.current_bpod = self._all_local_bpods[serials[index]]  # type: ignore
         else:
             if len(serials) > 1:
                 raise ValueError(f"{len(serials)} Bpods have been found! A serial"
                                  f" number or index is required!")
+            self.logger.info("Only one Bpod found!")
             self.current_bpod = self._all_local_bpods[serials[0]] # type: ignore
 
         return self.current_bpod

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -2,7 +2,7 @@ import logging
 import multiprocessing as mp
 from multiprocessing.connection import Connection
 from pathlib import Path
-from typing import cast, Optional, TypeAlias
+from typing import Optional, TypeAlias, cast
 
 from bpod_core.bpod import Bpod, BpodInfo, discover_bpod, discover_remote_bpod
 
@@ -19,15 +19,15 @@ class BpodManager:
         self._all_local_bpods: dict[SerialNumber, BpodInfo] | None = None
         # self.remote_bpods: dict[SerialNumber, BpodInfo] | None = None
 
-        self.last_selected_bpod: BpodInfo | None = None
+        self.current_bpod: BpodInfo | None = None
 
 
     def load(self):
         self._get_local_bpods()
 
 
-    def select_bpod(self, serial: SerialNumber = None, index: int = 0) -> BpodInfo:
-        """Returns a BpodInfo instance
+    def select_bpod(self, serial: SerialNumber | None = None, index: int = 0) -> BpodInfo:
+        """Returns a BpodInfo instance.
 
         Function will return the BpodInfo instance with the given serial number or
         index. serial will always take precedence over index. If no parameter is
@@ -42,27 +42,26 @@ class BpodManager:
 
         Returns
         -------
-
         BpodInfo instance
 
         """
-
         if self._all_local_bpods is None:
             raise ValueError("No local Bpods found!")
+
 
         serials: list[SerialNumber] = list(self._all_local_bpods.keys())
 
         if serial is not None:
-            if serial in self._all_local_bpods.keys():
-                self.last_selected_bpod = self._all_local_bpods[serial]
+            if serial in serials:
+                self.current_bpod = self._all_local_bpods[serial] # type: ignore
             else:
                 raise KeyError(f"Bpod {serial} not found!")
+        else:
+            if index > len(serials) or index < 0:
+                raise IndexError(f"Index {index} out of range!")
+            self.current_bpod = self._all_local_bpods[serials[index]] # type: ignore
 
-        if index > len(serials) or index < 0:
-            raise IndexError(f"Index {index} out of range!")
-
-        self.last_selected_bpod = self._all_local_bpods[serials[index]]
-        return self.last_selected_bpod
+        return self.current_bpod
 
 
     def _format_all_bpods_info(self):
@@ -73,15 +72,20 @@ class BpodManager:
             f"[{i}]: Local Bpod\n"
             f"Name: {info.name} | Serial Number: {sn}\n"
             f"Port: {info.port} | Location: {info.location}\n\n"
-            for i, sn, info in enumerate(self._all_local_bpods.items())
+            for i, (sn, info) in enumerate(self._all_local_bpods.items())
         ]
 
-        return f"The following Bpods are available:\n{info}"
+        return f"The following Bpods are available:\n {info}"
 
 
     def _get_local_bpods(self):
-        local_bpods = discover_bpod()
+        local_bpods = list(discover_bpod())
         # remote_bpods = discover_remote_bpod()
+
+        if len(local_bpods) == 0:
+            self._all_local_bpods = None
+            self.logger.warning("No local Bpods found!")
+            return None
 
         self._all_local_bpods = {
             info.serial_number: info
@@ -92,18 +96,13 @@ class BpodManager:
         #     for info in remote_bpods
         # }
 
-        if self._all_local_bpods is None:
-            self.logger.warning("No local Bpods found!")
-
         return self._all_local_bpods
 
 
     @property
     def bpod(self):
-        if self.last_selected_bpod is not None:
-            return self.last_selected_bpod
-        else:
-            return None
+        return self.current_bpod
+
 
     def __str__(self):
         return self._format_all_bpods_info()

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -78,10 +78,12 @@ class BpodManager:
             self.current_bpod = self._all_local_bpods[serials[index]]  # type: ignore
         else:
             if len(serials) > 1:
-                raise ValueError(f"{len(serials)} Bpods have been found! A serial"
-                                 f" number or index is required!")
+                raise ValueError(
+                    f"{len(serials)} Bpods have been found! A serial"
+                    f" number or index is required!"
+                )
             self.logger.info("Only one Bpod found!")
-            self.current_bpod = self._all_local_bpods[serials[0]] # type: ignore
+            self.current_bpod = self._all_local_bpods[serials[0]]  # type: ignore
 
         return self.current_bpod
 

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -1,8 +1,9 @@
-import logging
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, TypeAlias
 
 from bpod_core.bpod import discover_bpod
 from bpod_core.bpod.structs import BpodInfo
+
+from bpod_rig import log
 
 if TYPE_CHECKING:
     from bpod_rig.log import BpodLogger
@@ -13,7 +14,7 @@ SerialNumber: TypeAlias = str
 
 class BpodManager:
     def __init__(self) -> None:
-        self.logger: BpodLogger = cast("BpodLogger", logging.getLogger(__name__))
+        self.logger: BpodLogger = log.get_logger(self.__class__.__name__)
         self._all_local_bpods: dict[SerialNumber, BpodInfo] | None = None
         # self.remote_bpods: dict[SerialNumber, BpodInfo] | None = None
 

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -1,7 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, TypeAlias, cast
 
-from bpod_core.bpod import BpodInfo, discover_bpod
+from bpod_core.bpod import discover_bpod
+from bpod_core.bpod.structs import BpodInfo
 
 if TYPE_CHECKING:
     from bpod_rig.log import BpodLogger

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -73,7 +73,7 @@ class BpodManager:
             self.current_bpod = self._all_local_bpods[serials[index]]  # type: ignore
         else:
             if len(serials) > 1:
-                raise IndexError(f"{len(serials)} Bpods have been found! A serial"
+                raise ValueError(f"{len(serials)} Bpods have been found! A serial"
                                  f" number or index is required!")
             self.current_bpod = self._all_local_bpods[serials[0]] # type: ignore
 

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -98,7 +98,11 @@ class BpodManager:
             for i, (sn, info) in enumerate(self._all_local_bpods.items())
         ]
 
-        return f"The following Bpods are available:\n {info}"
+        return (
+            f"\nThe following Bpods are available:\n"
+            f"===================================\n"
+            f"{''.join(info)}"
+        )
 
     def _get_local_bpods(self) -> dict[SerialNumber, BpodInfo] | None:
         local_bpods = list(discover_bpod())

--- a/bpod_rig/managers/bpod_manager.py
+++ b/bpod_rig/managers/bpod_manager.py
@@ -25,13 +25,18 @@ class BpodManager:
         self._get_local_bpods()
 
     def select_bpod(
-        self, serial: SerialNumber | None = None, index: int = 0
+        self, serial: SerialNumber | None = None, index: int | None = None
     ) -> BpodInfo:
-        """Returns a BpodInfo instance.
+        """Returns a BpodInfo instance requested by the user.
 
-        Function will return the BpodInfo instance with the given serial number or
-        index. serial will always take precedence over index. If no parameter is
-        provided, the first BpodInfo instance will be returned.
+        If there is only one Bpod found, no identifiers are required.
+
+        If there are multiple Bpods, an identifier is required. If an identifier is not
+        provided when required, an error will be raised.
+
+        If identifiers are provided, they must exist or an error will be raised. If
+        both a serial number and index are provided, the serial will always take
+        precedence.
 
         Parameters
         ----------
@@ -42,7 +47,14 @@ class BpodManager:
 
         Returns
         -------
-        BpodInfo instance
+            BpodInfo instance
+
+        Raises
+        ------
+            ValueError
+                Raised if no Bpod is found, an identifier is not provided when required,
+                or the identifier does not exist
+
 
         """
         if self._all_local_bpods is None:
@@ -54,11 +66,16 @@ class BpodManager:
             if serial in serials:
                 self.current_bpod = self._all_local_bpods[serial]  # type: ignore
             else:
-                raise KeyError(f"Bpod {serial} not found!")
-        else:
-            if index > len(serials) or index < 0:
+                raise ValueError(f"Bpod {serial} not found!")
+        elif index is not None:
+            if 0 > index > len(serials):
                 raise IndexError(f"Index {index} out of range!")
             self.current_bpod = self._all_local_bpods[serials[index]]  # type: ignore
+        else:
+            if len(serials) > 1:
+                raise IndexError(f"{len(serials)} Bpods have been found! A serial"
+                                 f" number or index is required!")
+            self.current_bpod = self._all_local_bpods[serials[0]] # type: ignore
 
         return self.current_bpod
 

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -5,17 +5,14 @@ from bpod_core.bpod.structs import BpodInfo
 
 from bpod_rig.managers import BpodManager
 
-bpod_info_1 = BpodInfo(
-    serial_number="abc123",
-    port="COM2",
-    name="Bpod 1"
-)
+bpod_info_1 = BpodInfo(serial_number="abc123", port="COM2", name="Bpod 1")
 
 bpod_info_2 = BpodInfo(
     serial_number="xyz456",
     port="COM3",
     name="Bpod 2",
 )
+
 
 def mock_discover_bpod(num_bpods: int = 2) -> Generator[BpodInfo]:
     if num_bpods > 2:
@@ -43,7 +40,7 @@ class TestBpodManager:
             num_bpods = marker.args[0]
             monkeypatch.setattr(
                 "bpod_rig.managers.bpod_manager.discover_bpod",
-                lambda: mock_discover_bpod(num_bpods)
+                lambda: mock_discover_bpod(num_bpods),
             )
 
         self.bpm = BpodManager()
@@ -89,7 +86,6 @@ class TestBpodManager:
         compare_bpod_info(self.bpm.current_bpod, bpod_info_1)
         compare_bpod_info(returned_bpod, bpod_info_1)
 
-
     @pytest.mark.finds_bpods(2)
     def test_select_multiple_bpods(self) -> None:
 
@@ -112,7 +108,6 @@ class TestBpodManager:
         assert self.bpm.current_bpod is not None
         compare_bpod_info(self.bpm.current_bpod, bpod_info_2)
         compare_bpod_info(returned_bpod, bpod_info_2)
-
 
     @pytest.mark.finds_bpods(2)
     def test_select_bpod_errors(self, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -5,17 +5,9 @@ from bpod_core.bpod.structs import BpodInfo
 
 from bpod_rig.managers import BpodManager
 
-bpod_info_1 = BpodInfo(
-    serial_number="serial123",
-    port="COM2",
-    name="Bpod 1"
-)
+bpod_info_1 = BpodInfo(serial_number="serial123", port="COM2", name="Bpod 1")
 
-bpod_info_2 = BpodInfo(
-    serial_number="serial456",
-    port="COM3",
-    name="Bpod 2",
-)
+bpod_info_2 = BpodInfo(serial_number="serial456", port="COM3", name="Bpod 2")
 
 
 def mock_discover_bpod(num_bpods: int = 2) -> Generator[BpodInfo]:

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -1,0 +1,95 @@
+from typing import Generator
+
+import pytest
+from bpod_core.bpod import BpodInfo, discover_bpod
+
+from bpod_rig.managers import BpodManager
+
+
+def mock_discover_bpod() -> Generator[BpodInfo]:
+
+    bpod_info_1 = BpodInfo(
+        serial_number = "abc123",
+        port = "COM2",
+        name = "Bpod 1"
+    )
+
+    bpod_info_2 = BpodInfo(
+        serial_number = "xyz456",
+        port = "COM3",
+        name = "Bpod 2",
+    )
+
+    for bpod in [bpod_info_1, bpod_info_2]:
+        yield bpod
+
+
+class TestBpodManager:
+
+    @pytest.fixture(autouse=True)
+    def create_bpm(self, request, monkeypatch):
+        marker = request.node.get_closest_marker("finds_bpods").args[0]
+        print(marker)
+        if not marker:
+            monkeypatch.setattr("bpod_rig.managers.bpod_manager.discover_bpod", list)
+        else:
+            monkeypatch.setattr(
+                "bpod_rig.managers.bpod_manager.discover_bpod", mock_discover_bpod
+                )
+
+        self.bpm = BpodManager()
+        self.bpm.load()
+
+
+    @pytest.mark.finds_bpods(False)
+    def test_discover_no_bpods(self, caplog):
+        self.bpm.load()
+        assert "No local Bpods found!" in caplog.messages
+        assert self.bpm._all_local_bpods is None
+        assert self.bpm._get_local_bpods() is None
+
+    @pytest.mark.finds_bpods(True)
+    def test_discover_bpods(self):
+        assert self.bpm._all_local_bpods is not None
+        assert list(self.bpm._all_local_bpods.keys()) == ["abc123", "xyz456"]
+        assert self.bpm._get_local_bpods() is self.bpm._all_local_bpods
+
+    @pytest.mark.finds_bpods(False)
+    def test_select_bpod_no_bpods(self):
+        with pytest.raises(ValueError):
+            self.bpm.select_bpod()
+
+    @pytest.mark.finds_bpods(True)
+    def test_select_bpod(self):
+
+        assert self.bpm._all_local_bpods is not None
+
+        current_bpod = self.bpm.select_bpod()
+        assert self.bpm.current_bpod is current_bpod
+        assert self.bpm.current_bpod is self.bpm._all_local_bpods["abc123"]
+        assert self.bpm.current_bpod is not self.bpm._all_local_bpods["xyz456"]
+        assert self.bpm.current_bpod.port == "COM2"
+        assert self.bpm.current_bpod.name == "Bpod 1"
+
+        self.bpm.select_bpod(serial = "xyz456")
+        assert self.bpm.current_bpod is self.bpm._all_local_bpods["xyz456"]
+        assert self.bpm.current_bpod.serial_number == "xyz456"
+        assert self.bpm.current_bpod.port == "COM3"
+        assert self.bpm.current_bpod.name == "Bpod 2"
+
+        self.bpm.select_bpod(index=1)
+        assert self.bpm.current_bpod is self.bpm._all_local_bpods["xyz456"]
+        assert self.bpm.current_bpod.serial_number == "xyz456"
+        assert self.bpm.current_bpod.port == "COM3"
+        assert self.bpm.current_bpod.name == "Bpod 2"
+
+    @pytest.mark.finds_bpods(True)
+    def test_select_bpod_errors(self):
+        with pytest.raises(KeyError):
+            self.bpm.select_bpod(serial="bad_serial")
+
+        with pytest.raises(IndexError):
+            self.bpm.select_bpod(index=99)
+
+        with pytest.raises(IndexError):
+            self.bpm.select_bpod(index=-99)

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -5,10 +5,14 @@ from bpod_core.bpod.structs import BpodInfo
 
 from bpod_rig.managers import BpodManager
 
-bpod_info_1 = BpodInfo(serial_number="abc123", port="COM2", name="Bpod 1")
+bpod_info_1 = BpodInfo(
+    serial_number="serial123",
+    port="COM2",
+    name="Bpod 1"
+)
 
 bpod_info_2 = BpodInfo(
-    serial_number="xyz456",
+    serial_number="serial456",
     port="COM3",
     name="Bpod 2",
 )
@@ -55,7 +59,7 @@ class TestBpodManager:
     @pytest.mark.finds_bpods(2)
     def test_discover_bpods(self) -> None:
         assert self.bpm._all_local_bpods is not None
-        assert list(self.bpm._all_local_bpods.keys()) == ["abc123", "xyz456"]
+        assert list(self.bpm._all_local_bpods.keys()) == ["serial123", "serial456"]
         # Is the value returned correctly?
         assert self.bpm._get_local_bpods() is self.bpm._all_local_bpods
 
@@ -81,20 +85,24 @@ class TestBpodManager:
 
         # Reset current bpod and test select by serial
         self.bpm.current_bpod = None
-        returned_bpod = self.bpm.select_bpod(serial="abc123")
+        returned_bpod = self.bpm.select_bpod(serial="serial123")
         assert self.bpm.current_bpod is not None
         compare_bpod_info(self.bpm.current_bpod, bpod_info_1)
         compare_bpod_info(returned_bpod, bpod_info_1)
 
     @pytest.mark.finds_bpods(2)
-    def test_select_multiple_bpods(self) -> None:
+    def test_select_multiple_bpods(self, caplog: pytest.LogCaptureFixture) -> None:
 
-        returned_bpod = self.bpm.select_bpod(serial="abc123")
+        with pytest.raises(ValueError):
+            self.bpm.select_bpod()
+            assert "A serial number or index is required!" in caplog.messages
+
+        returned_bpod = self.bpm.select_bpod(serial="serial123")
         assert self.bpm.current_bpod is not None
         compare_bpod_info(self.bpm.current_bpod, bpod_info_1)
         compare_bpod_info(returned_bpod, bpod_info_1)
 
-        returned_bpod = self.bpm.select_bpod(serial="xyz456")
+        returned_bpod = self.bpm.select_bpod(serial="serial456")
         assert self.bpm.current_bpod is not None
         compare_bpod_info(self.bpm.current_bpod, bpod_info_2)
         compare_bpod_info(returned_bpod, bpod_info_2)

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -1,66 +1,59 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
-from bpod_core.bpod import BpodInfo, discover_bpod
+from bpod_core.bpod import BpodInfo
 
 from bpod_rig.managers import BpodManager
 
 
 def mock_discover_bpod() -> Generator[BpodInfo]:
 
-    bpod_info_1 = BpodInfo(
-        serial_number = "abc123",
-        port = "COM2",
-        name = "Bpod 1"
-    )
+    bpod_info_1 = BpodInfo(serial_number="abc123", port="COM2", name="Bpod 1")
 
     bpod_info_2 = BpodInfo(
-        serial_number = "xyz456",
-        port = "COM3",
-        name = "Bpod 2",
+        serial_number="xyz456",
+        port="COM3",
+        name="Bpod 2",
     )
 
-    for bpod in [bpod_info_1, bpod_info_2]:
-        yield bpod
+    yield from [bpod_info_1, bpod_info_2]
 
 
 class TestBpodManager:
-
     @pytest.fixture(autouse=True)
-    def create_bpm(self, request, monkeypatch):
-        marker = request.node.get_closest_marker("finds_bpods").args[0]
-        print(marker)
+    def create_bpm(
+        self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        marker = request.node.get_closest_marker("finds_bpods")
         if not marker:
             monkeypatch.setattr("bpod_rig.managers.bpod_manager.discover_bpod", list)
         else:
             monkeypatch.setattr(
                 "bpod_rig.managers.bpod_manager.discover_bpod", mock_discover_bpod
-                )
+            )
 
         self.bpm = BpodManager()
-        self.bpm.load()
+        self.bpm.refresh()
 
-
-    @pytest.mark.finds_bpods(False)
-    def test_discover_no_bpods(self, caplog):
-        self.bpm.load()
+    def test_discover_no_bpods(self, caplog: pytest.LogCaptureFixture) -> None:
+        self.bpm.refresh()
         assert "No local Bpods found!" in caplog.messages
         assert self.bpm._all_local_bpods is None
         assert self.bpm._get_local_bpods() is None
 
-    @pytest.mark.finds_bpods(True)
-    def test_discover_bpods(self):
+    @pytest.mark.finds_bpods
+    def test_discover_bpods(self) -> None:
         assert self.bpm._all_local_bpods is not None
         assert list(self.bpm._all_local_bpods.keys()) == ["abc123", "xyz456"]
         assert self.bpm._get_local_bpods() is self.bpm._all_local_bpods
 
-    @pytest.mark.finds_bpods(False)
-    def test_select_bpod_no_bpods(self):
+    # @pytest.mark.finds_bpods(False)
+    def test_select_bpod_no_bpods(self) -> None:
         with pytest.raises(ValueError):
             self.bpm.select_bpod()
 
-    @pytest.mark.finds_bpods(True)
-    def test_select_bpod(self):
+    @pytest.mark.finds_bpods
+    def test_select_bpod(self) -> None:
 
         assert self.bpm._all_local_bpods is not None
 
@@ -71,7 +64,7 @@ class TestBpodManager:
         assert self.bpm.current_bpod.port == "COM2"
         assert self.bpm.current_bpod.name == "Bpod 1"
 
-        self.bpm.select_bpod(serial = "xyz456")
+        self.bpm.select_bpod(serial="xyz456")
         assert self.bpm.current_bpod is self.bpm._all_local_bpods["xyz456"]
         assert self.bpm.current_bpod.serial_number == "xyz456"
         assert self.bpm.current_bpod.port == "COM3"
@@ -83,8 +76,8 @@ class TestBpodManager:
         assert self.bpm.current_bpod.port == "COM3"
         assert self.bpm.current_bpod.name == "Bpod 2"
 
-    @pytest.mark.finds_bpods(True)
-    def test_select_bpod_errors(self):
+    @pytest.mark.finds_bpods
+    def test_select_bpod_errors(self) -> None:
         with pytest.raises(KeyError):
             self.bpm.select_bpod(serial="bad_serial")
 

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -58,6 +58,9 @@ class TestBpodManager:
         assert self.bpm._all_local_bpods is not None
 
         current_bpod = self.bpm.select_bpod()
+        assert current_bpod is not None
+
+        assert self.bpm.current_bpod is not None
         assert self.bpm.current_bpod is current_bpod
         assert self.bpm.current_bpod is self.bpm._all_local_bpods["abc123"]
         assert self.bpm.current_bpod is not self.bpm._all_local_bpods["xyz456"]
@@ -65,6 +68,7 @@ class TestBpodManager:
         assert self.bpm.current_bpod.name == "Bpod 1"
 
         self.bpm.select_bpod(serial="xyz456")
+        assert self.bpm.current_bpod is not None
         assert self.bpm.current_bpod is self.bpm._all_local_bpods["xyz456"]
         assert self.bpm.current_bpod.serial_number == "xyz456"
         assert self.bpm.current_bpod.port == "COM3"

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -92,11 +92,6 @@ class TestBpodManager:
 
     @pytest.mark.finds_bpods(2)
     def test_select_multiple_bpods(self, caplog: pytest.LogCaptureFixture) -> None:
-
-        with pytest.raises(ValueError):
-            self.bpm.select_bpod()
-            assert "A serial number or index is required!" in caplog.messages
-
         returned_bpod = self.bpm.select_bpod(serial="serial123")
         assert self.bpm.current_bpod is not None
         compare_bpod_info(self.bpm.current_bpod, bpod_info_1)

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -5,18 +5,30 @@ from bpod_core.bpod.structs import BpodInfo
 
 from bpod_rig.managers import BpodManager
 
+bpod_info_1 = BpodInfo(
+    serial_number="abc123",
+    port="COM2",
+    name="Bpod 1"
+)
 
-def mock_discover_bpod() -> Generator[BpodInfo]:
+bpod_info_2 = BpodInfo(
+    serial_number="xyz456",
+    port="COM3",
+    name="Bpod 2",
+)
 
-    bpod_info_1 = BpodInfo(serial_number="abc123", port="COM2", name="Bpod 1")
+def mock_discover_bpod(num_bpods: int = 2) -> Generator[BpodInfo]:
+    if num_bpods > 2:
+        raise IndexError("Too many Bpods requested!")
 
-    bpod_info_2 = BpodInfo(
-        serial_number="xyz456",
-        port="COM3",
-        name="Bpod 2",
-    )
+    yield from [bpod_info_1, bpod_info_2][:num_bpods]
 
-    yield from [bpod_info_1, bpod_info_2]
+
+def compare_bpod_info(selected_bpod: BpodInfo, expected_bpod: BpodInfo) -> None:
+    assert selected_bpod.serial_number == expected_bpod.serial_number
+    assert selected_bpod.name == expected_bpod.name
+    assert selected_bpod.port == expected_bpod.port
+    assert selected_bpod is expected_bpod
 
 
 class TestBpodManager:
@@ -28,8 +40,10 @@ class TestBpodManager:
         if not marker:
             monkeypatch.setattr("bpod_rig.managers.bpod_manager.discover_bpod", list)
         else:
+            num_bpods = marker.args[0]
             monkeypatch.setattr(
-                "bpod_rig.managers.bpod_manager.discover_bpod", mock_discover_bpod
+                "bpod_rig.managers.bpod_manager.discover_bpod",
+                lambda: mock_discover_bpod(num_bpods)
             )
 
         self.bpm = BpodManager()
@@ -41,52 +55,80 @@ class TestBpodManager:
         assert self.bpm._all_local_bpods is None
         assert self.bpm._get_local_bpods() is None
 
-    @pytest.mark.finds_bpods
+    @pytest.mark.finds_bpods(2)
     def test_discover_bpods(self) -> None:
         assert self.bpm._all_local_bpods is not None
         assert list(self.bpm._all_local_bpods.keys()) == ["abc123", "xyz456"]
+        # Is the value returned correctly?
         assert self.bpm._get_local_bpods() is self.bpm._all_local_bpods
 
-    # @pytest.mark.finds_bpods(False)
     def test_select_bpod_no_bpods(self) -> None:
         with pytest.raises(ValueError):
             self.bpm.select_bpod()
 
-    @pytest.mark.finds_bpods
-    def test_select_bpod(self) -> None:
+    @pytest.mark.finds_bpods(1)
+    def test_select_one_bpod(self) -> None:
 
-        assert self.bpm._all_local_bpods is not None
-
-        current_bpod = self.bpm.select_bpod()
-        assert current_bpod is not None
-
+        # Test No Parameters
+        returned_bpod = self.bpm.select_bpod()
         assert self.bpm.current_bpod is not None
-        assert self.bpm.current_bpod is current_bpod
-        assert self.bpm.current_bpod is self.bpm._all_local_bpods["abc123"]
-        assert self.bpm.current_bpod is not self.bpm._all_local_bpods["xyz456"]
-        assert self.bpm.current_bpod.port == "COM2"
-        assert self.bpm.current_bpod.name == "Bpod 1"
+        compare_bpod_info(self.bpm.current_bpod, bpod_info_1)
+        compare_bpod_info(returned_bpod, bpod_info_1)
 
-        self.bpm.select_bpod(serial="xyz456")
+        # Reset current bpod and test select by index
+        self.bpm.current_bpod = None
+        returned_bpod = self.bpm.select_bpod(index=0)
         assert self.bpm.current_bpod is not None
-        assert self.bpm.current_bpod is self.bpm._all_local_bpods["xyz456"]
-        assert self.bpm.current_bpod.serial_number == "xyz456"
-        assert self.bpm.current_bpod.port == "COM3"
-        assert self.bpm.current_bpod.name == "Bpod 2"
+        compare_bpod_info(self.bpm.current_bpod, bpod_info_1)
+        compare_bpod_info(returned_bpod, bpod_info_1)
 
-        self.bpm.select_bpod(index=1)
-        assert self.bpm.current_bpod is self.bpm._all_local_bpods["xyz456"]
-        assert self.bpm.current_bpod.serial_number == "xyz456"
-        assert self.bpm.current_bpod.port == "COM3"
-        assert self.bpm.current_bpod.name == "Bpod 2"
+        # Reset current bpod and test select by serial
+        self.bpm.current_bpod = None
+        returned_bpod = self.bpm.select_bpod(serial="abc123")
+        assert self.bpm.current_bpod is not None
+        compare_bpod_info(self.bpm.current_bpod, bpod_info_1)
+        compare_bpod_info(returned_bpod, bpod_info_1)
 
-    @pytest.mark.finds_bpods
-    def test_select_bpod_errors(self) -> None:
-        with pytest.raises(KeyError):
+
+    @pytest.mark.finds_bpods(2)
+    def test_select_multiple_bpods(self) -> None:
+
+        returned_bpod = self.bpm.select_bpod(serial="abc123")
+        assert self.bpm.current_bpod is not None
+        compare_bpod_info(self.bpm.current_bpod, bpod_info_1)
+        compare_bpod_info(returned_bpod, bpod_info_1)
+
+        returned_bpod = self.bpm.select_bpod(serial="xyz456")
+        assert self.bpm.current_bpod is not None
+        compare_bpod_info(self.bpm.current_bpod, bpod_info_2)
+        compare_bpod_info(returned_bpod, bpod_info_2)
+
+        returned_bpod = self.bpm.select_bpod(index=0)
+        assert self.bpm.current_bpod is not None
+        compare_bpod_info(self.bpm.current_bpod, bpod_info_1)
+        compare_bpod_info(returned_bpod, bpod_info_1)
+
+        returned_bpod = self.bpm.select_bpod(index=1)
+        assert self.bpm.current_bpod is not None
+        compare_bpod_info(self.bpm.current_bpod, bpod_info_2)
+        compare_bpod_info(returned_bpod, bpod_info_2)
+
+
+    @pytest.mark.finds_bpods(2)
+    def test_select_bpod_errors(self, caplog: pytest.LogCaptureFixture) -> None:
+        with pytest.raises(ValueError):
+            # Parameters are required with multiple Bpods
+            self.bpm.select_bpod()
+            assert "A serial number or index is required!" in caplog.messages
+
+        with pytest.raises(ValueError):
             self.bpm.select_bpod(serial="bad_serial")
+            assert "not found" in caplog.messages
 
         with pytest.raises(IndexError):
             self.bpm.select_bpod(index=99)
+            assert "out of range" in caplog.messages
 
         with pytest.raises(IndexError):
             self.bpm.select_bpod(index=-99)
+            assert "out of range" in caplog.messages

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -130,3 +130,35 @@ class TestBpodManager:
         with pytest.raises(IndexError):
             self.bpm.select_bpod(index=-99)
             assert "out of range" in caplog.messages
+
+    def test_format_no_bpods(self) -> None:
+        string_rep = str(self.bpm)
+        assert string_rep == "No local Bpods found to list!"
+
+    @pytest.mark.finds_bpods(1)
+    def test_format_one_bpod(self) -> None:
+        string_rep = str(self.bpm)
+        assert string_rep == (
+            "\nThe following Bpods are available:\n"
+            "===================================\n"
+            "[0]: Local Bpod\n"
+            "Name: Bpod 1 | Serial Number: serial123\n"
+            "Port: COM2 | Location: \n"
+            "\n"
+        )
+
+    @pytest.mark.finds_bpods(2)
+    def test_format_two_bpods(self) -> None:
+        string_rep = str(self.bpm)
+        assert string_rep == (
+            "\nThe following Bpods are available:\n"
+            "===================================\n"
+            "[0]: Local Bpod\n"
+            "Name: Bpod 1 | Serial Number: serial123\n"
+            "Port: COM2 | Location: \n"
+            "\n"
+            "[1]: Local Bpod\n"
+            "Name: Bpod 2 | Serial Number: serial456\n"
+            "Port: COM3 | Location: \n"
+            "\n"
+        )

--- a/tests/bpod_rig/managers/test_bpod_manager.py
+++ b/tests/bpod_rig/managers/test_bpod_manager.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 
 import pytest
-from bpod_core.bpod import BpodInfo
+from bpod_core.bpod.structs import BpodInfo
 
 from bpod_rig.managers import BpodManager
 


### PR DESCRIPTION
Add a simple BpodManager class to help poll and select Bpods discovered by `bpod-core`

- Lists all local Bpods
- Allows user to select based on Serial Number or index
- Outputs a Formatted List
- Retains last selected Bpod for quick reference if connections are opened/closed
- Unit testing for above
Currently does not support RemoteBpod as I am waiting for changes to `bpod-core` where Bpod and RemoteBpod will be combined into a factory class

Below needs to be done later!:

- [x] Attempt to connect to a Bpod that has been selected
- [x] Return as object
- [x] Return as process/thread (if desired)

This has been extracted from the mess that is #73 