### PR TITLE
add [tool.pyright] config values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ exclude-newer = "2 weeks"
 exclude-newer-package = { bpod-core = false }
 required-version = ">=0.11.15"
 
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+
+
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [


### PR DESCRIPTION
`pyright` has a known issue where it will fail to use the local `.venv` for package resolution: https://github.com/microsoft/pyright/issues/3378

Addition of `[tool.pyright]` section to `pyproject.toml` to explicitly point to the local `.venv` directory.

Path needs to be updated manually if the venv is created elsewhere