### PR TITLE
Cleanup justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,29 +1,33 @@
 # List available commands
+[private]
 default:
-    just --list
+    @just --list --unsorted
 
 # Check formatting and types
-
-check-ruff:
-    -uv run ruff check .
-
-check-format:
-    -uv run ruff format --check .
-
-check-types:
-    -uv run pyright .
-
-check: check-format check-ruff check-types
-
-# Run tests, excluding hardware tests
-test ARGS=".":
-    uv run pytest {{ ARGS }}
-
-# Run all tests including tests requiring hardware
-test-hardware port="None" serial_number="None":
-    uv run pytest --runhardware --port={{ port }} --serial-number={{ serial_number }}
+check: _check-format _check-ruff _check-types
 
 # Automatically format files
 format:
     uv run ruff format .
     uv run ruff check --fix .
+
+# Run tests, excluding hardware tests. Takes optional arguments to pass to pytest.
+test *args:
+    uv run pytest {{ args }}
+
+# Run tests including tests requiring hardware.
+test-hardware port="None" serial_number="None" *args:
+    # Specify port OR serial number.
+    uv run pytest --runhardware --port={{ port }} --serial-number={{ serial_number }} {{ args }}
+
+# Subcommand to check code style with ruff (run by `check`)
+_check-ruff:
+    -uv run ruff check .
+
+# Subcommand to check formatting (run by `check`)
+_check-format:
+    -uv run ruff format --check .
+
+# Subcommand to check types (run by `check`)
+_check-types:
+    -uv run pyright .


### PR DESCRIPTION
I've cleaned up the justfile:

- Commands that would not realistically be used by themselves have been made private
- Using [variadic arguments](https://just.systems/man/en/recipe-parameters.html) in `test` recipes.

In practice, the change to the way that arguments are passed into test means that:
- Previously `just test "path/to/test.py --someparam"` (notice the quotes that Just will unpack)
- Now, `just test path/to/test.py --someparam`